### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,7 +4,11 @@
   "initialVersions": {
     "@metaflow/cli": "0.1.0",
     "@metaflow/engine": "0.1.0",
-    "metaflow": "0.1.0"
+    "metaflow": "0.1.0",
+    "metaflow-ai": "0.1.0"
   },
-  "changesets": ["minor-release-bump"]
+  "changesets": [
+    "minor-release-bump",
+    "release-manifest-alignment"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4642,10 +4642,10 @@
     },
     "packages/cli": {
       "name": "@metaflow/cli",
-      "version": "0.1.0-preview.0",
+      "version": "0.1.1-preview.1",
       "license": "MIT",
       "dependencies": {
-        "@metaflow/engine": "0.1.0-preview.0",
+        "@metaflow/engine": "0.1.1-preview.1",
         "commander": "^11.1.0",
         "jsonc-parser": "^3.3.1"
       },
@@ -4775,7 +4775,7 @@
     },
     "packages/engine": {
       "name": "@metaflow/engine",
-      "version": "0.1.0-preview.0",
+      "version": "0.1.1-preview.1",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
@@ -4904,10 +4904,10 @@
     },
     "src": {
       "name": "metaflow-ai",
-      "version": "0.1.0",
+      "version": "0.1.1-preview.1",
       "license": "MIT",
       "dependencies": {
-        "@metaflow/engine": "0.1.0-preview.0",
+        "@metaflow/engine": "0.1.1-preview.1",
         "jsonc-parser": "^3.3.1",
         "markdown-it": "^14.1.1"
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @metaflow/cli
 
+## 0.1.1-preview.1
+
+### Patch Changes
+
+- aa701d4: Align release-time manifest metadata with the current workspace package names and publishable dependency versions so Changesets and release preflight operate on the intended package graph.
+    - @metaflow/engine@0.1.1-preview.1
+
 ## 0.1.0-preview.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaflow/cli",
   "description": "CLI for layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.1.0-preview.0",
+  "version": "0.1.1-preview.1",
   "license": "MIT",
   "private": true,
   "bin": {
@@ -18,7 +18,7 @@
     "test:coverage": "c8 --reporter=text --reporter=lcov --include=\"out/src/**\" mocha \"out/test/**/*.test.js\" --timeout 10000"
   },
   "dependencies": {
-    "@metaflow/engine": "0.1.0-preview.0",
+    "@metaflow/engine": "0.1.1-preview.1",
     "commander": "^11.1.0",
     "jsonc-parser": "^3.3.1"
   },

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @metaflow/engine
 
+## 0.1.1-preview.1
+
 ## 0.1.0-preview.0
 
 ### Minor Changes

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaflow/engine",
   "description": "Engine for layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.1.0-preview.0",
+  "version": "0.1.1-preview.1",
   "license": "MIT",
   "private": true,
   "main": "out/src/index.js",

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1-preview.1
+
+### Patch Changes
+
+- aa701d4: Align release-time manifest metadata with the current workspace package names and publishable dependency versions so Changesets and release preflight operate on the intended package graph.
+    - @metaflow/engine@0.1.1-preview.1
+
 ## Unreleased
 
 ### Added

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "metaflow-ai",
   "displayName": "MetaFlow: AI Metadata Overlay",
   "description": "Layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.1.0",
+  "version": "0.1.1-preview.1",
   "publisher": "dynfxdigital",
   "license": "MIT",
   "repository": {
@@ -744,7 +744,7 @@
     "package": "vsce package --no-dependencies"
   },
   "dependencies": {
-    "@metaflow/engine": "0.1.0-preview.0",
+    "@metaflow/engine": "0.1.1-preview.1",
     "jsonc-parser": "^3.3.1",
     "markdown-it": "^14.1.1"
   },


### PR DESCRIPTION
Version Packages automation prepared this branch from aa701d4 but could not open the PR because GitHub Actions lacks pull-request creation permission. Opening it manually so the release path can continue.