### PR TITLE
chore(release): prepare preview release checks

### DIFF
--- a/.changeset/preview-0-3-0-release.md
+++ b/.changeset/preview-0-3-0-release.md
@@ -1,0 +1,7 @@
+---
+"metaflow-ai": minor
+"@metaflow/engine": minor
+"@metaflow/cli": minor
+---
+
+Prepare the 0.3.0 prerelease lane for preview extension publishing.

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -5014,6 +5014,10 @@ export function registerCommands(
             }
 
             const refreshOptions = extractRefreshCommandOptions(arg);
+            const autoAcceptRefreshUpdates =
+                context.extensionMode === vscode.ExtensionMode.Test;
+            const suppressRefreshUpdatePrompts =
+                refreshOptions.nonInteractive === true && !autoAcceptRefreshUpdates;
             const pendingCapabilityPluginMetadataDirtyVersion =
                 state.capabilityPluginMetadataDirtyVersion;
             logInfo('Refreshing overlay...');
@@ -5145,10 +5149,14 @@ export function registerCommands(
                         );
                     }
 
-                    const shouldPersistConfig = await confirmConfigUpdate(
-                        result.configPath,
-                        pendingConfigUpdateReasons,
-                    );
+                    const shouldPersistConfig = autoAcceptRefreshUpdates
+                        ? true
+                        : suppressRefreshUpdatePrompts
+                          ? false
+                          : await confirmConfigUpdate(
+                                result.configPath,
+                                pendingConfigUpdateReasons,
+                            );
 
                     if (shouldPersistConfig && capabilityRepairPreview) {
                         capabilityRepairPreview.repairResult = applyCapabilityIdentityDriftRepair(
@@ -5235,9 +5243,13 @@ export function registerCommands(
                     projectedConfigForBuiltInRepair,
                 );
                 if (builtInRepairPreview.repairs.length > 0) {
-                    const shouldUpdateBuiltInState = await confirmBuiltInCapabilityStateUpdate(
-                        builtInRepairPreview.repairs,
-                    );
+                    const shouldUpdateBuiltInState = autoAcceptRefreshUpdates
+                        ? true
+                        : suppressRefreshUpdatePrompts
+                          ? false
+                          : await confirmBuiltInCapabilityStateUpdate(
+                                builtInRepairPreview.repairs,
+                            );
                     if (shouldUpdateBuiltInState) {
                         state.builtInCapability = await writeBuiltInCapabilityWorkspaceState(
                             context,

--- a/src/src/commands/commandHelpers.ts
+++ b/src/src/commands/commandHelpers.ts
@@ -9,6 +9,7 @@ export interface RefreshCommandOptions {
     skipRepoSync?: boolean;
     skipSettingsInjection?: boolean;
     preferStateConfig?: boolean;
+    nonInteractive?: boolean;
     forceDiscovery?: boolean;
     forceDiscoveryRepoId?: string;
 }
@@ -459,6 +460,7 @@ export function extractRefreshCommandOptions(arg: unknown): RefreshCommandOption
     const skipSettingsInjection = (arg as { skipSettingsInjection?: unknown })
         .skipSettingsInjection;
     const preferStateConfig = (arg as { preferStateConfig?: unknown }).preferStateConfig;
+    const nonInteractive = (arg as { nonInteractive?: unknown }).nonInteractive;
     const forceDiscovery = (arg as { forceDiscovery?: unknown }).forceDiscovery;
     const forceDiscoveryRepoId = (arg as { forceDiscoveryRepoId?: unknown }).forceDiscoveryRepoId;
     return {
@@ -469,6 +471,7 @@ export function extractRefreshCommandOptions(arg: unknown): RefreshCommandOption
         skipSettingsInjection:
             typeof skipSettingsInjection === 'boolean' ? skipSettingsInjection : undefined,
         preferStateConfig: typeof preferStateConfig === 'boolean' ? preferStateConfig : undefined,
+        nonInteractive: typeof nonInteractive === 'boolean' ? nonInteractive : undefined,
         forceDiscovery: typeof forceDiscovery === 'boolean' ? forceDiscovery : undefined,
         forceDiscoveryRepoId:
             typeof forceDiscoveryRepoId === 'string' ? forceDiscoveryRepoId : undefined,

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -682,7 +682,7 @@ suite('Command Execution', function () {
         const settingsOnlyConfig = {
             metadataRepos: [{ id: 'settings', localPath: '.ai/settings-only-repo', enabled: true }],
             layerSources: [{ repoId: 'settings', path: 'settings-only', enabled: true }],
-            filters: { include: ['instructions/**'], exclude: [] },
+            filters: { include: ['**'], exclude: [] },
             profiles: {
                 default: {
                     enable: ['**/*'],
@@ -707,10 +707,11 @@ suite('Command Execution', function () {
             return undefined;
         };
 
-        await wsConfig.update(
+        await updateConfigAndWait(
             'chat.instructionsFilesLocations',
             undefined,
             vscode.ConfigurationTarget.Workspace,
+            wsFolder,
         );
         await metaflowConfig.update('autoApply', false, vscode.ConfigurationTarget.Workspace);
         await metaflowConfig.update(
@@ -732,8 +733,19 @@ suite('Command Execution', function () {
                 'Apply should not show a completion toast when no Synchronized files are written',
             );
 
-            const instructionLocations = getInjectedLocationValue(
-                wsConfig.inspect<Record<string, boolean>>('chat.instructionsFilesLocations'),
+            await waitFor(() => {
+                const freshConfig = vscode.workspace.getConfiguration(undefined, wsFolder.uri);
+                const instructionLocations = getScopedSettingValue<Record<string, boolean>>(
+                    freshConfig,
+                    'chat.instructionsFilesLocations',
+                );
+                return !!instructionLocations && Object.keys(instructionLocations).length > 0;
+            });
+
+            const freshConfig = vscode.workspace.getConfiguration(undefined, wsFolder.uri);
+            const instructionLocations = getScopedSettingValue<Record<string, boolean>>(
+                freshConfig,
+                'chat.instructionsFilesLocations',
             );
             assert.ok(
                 instructionLocations && Object.keys(instructionLocations).length > 0,

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -168,7 +168,11 @@ suite('Command Execution', function () {
                 remove(movedPath);
             } catch (secondError: unknown) {
                 const secondCode = (secondError as NodeJS.ErrnoException | undefined)?.code;
-                if (secondCode !== 'EPERM' && secondCode !== 'EBUSY' && secondCode !== 'ENOTEMPTY') {
+                if (
+                    secondCode !== 'EPERM' &&
+                    secondCode !== 'EBUSY' &&
+                    secondCode !== 'ENOTEMPTY'
+                ) {
                     throw secondError;
                 }
             }
@@ -2450,15 +2454,16 @@ suite('Command Execution', function () {
 
         const originalExecuteCommand = vscode.commands.executeCommand;
         const calls: Array<{ command: string; args: unknown[] }> = [];
-        (vscode.commands as unknown as { executeCommand: typeof vscode.commands.executeCommand }).executeCommand =
-            (async (command: string, ...args: unknown[]) => {
-                calls.push({ command, args });
-                if (command === 'revealInExplorer') {
-                    return;
-                }
+        (
+            vscode.commands as unknown as { executeCommand: typeof vscode.commands.executeCommand }
+        ).executeCommand = (async (command: string, ...args: unknown[]) => {
+            calls.push({ command, args });
+            if (command === 'revealInExplorer') {
+                return;
+            }
 
-                return originalExecuteCommand(command as never, ...(args as []));
-            }) as typeof vscode.commands.executeCommand;
+            return originalExecuteCommand(command as never, ...(args as []));
+        }) as typeof vscode.commands.executeCommand;
 
         try {
             const openedPath = (await vscode.commands.executeCommand('metaflow.openWarningSource', {
@@ -2473,13 +2478,17 @@ suite('Command Execution', function () {
                     (call) =>
                         call.command === 'revealInExplorer' &&
                         call.args[0] instanceof vscode.Uri &&
-                        path.normalize((call.args[0] as vscode.Uri).fsPath) === path.normalize(sourcePath),
+                        path.normalize((call.args[0] as vscode.Uri).fsPath) ===
+                            path.normalize(sourcePath),
                 ),
                 'openWarningSource should reveal the exact warning directory in Explorer',
             );
         } finally {
-            (vscode.commands as unknown as { executeCommand: typeof vscode.commands.executeCommand }).executeCommand =
-                originalExecuteCommand;
+            (
+                vscode.commands as unknown as {
+                    executeCommand: typeof vscode.commands.executeCommand;
+                }
+            ).executeCommand = originalExecuteCommand;
             removeDirectoryRecursive(warningRoot);
         }
     });

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -118,13 +118,61 @@ suite('Command Execution', function () {
         return JSON.parse(JSON.stringify(value)) as T;
     }
 
+    function chmodRecursive(targetPath: string): void {
+        if (!fs.existsSync(targetPath)) {
+            return;
+        }
+
+        const stat = fs.lstatSync(targetPath);
+        if (stat.isDirectory()) {
+            for (const entry of fs.readdirSync(targetPath)) {
+                chmodRecursive(path.join(targetPath, entry));
+            }
+        }
+
+        try {
+            fs.chmodSync(targetPath, 0o777);
+        } catch {
+            // Best-effort cleanup support for transient Windows file locks.
+        }
+    }
+
     function removeDirectoryRecursive(targetPath: string): void {
-        fs.rmSync(targetPath, {
-            recursive: true,
-            force: true,
-            maxRetries: 20,
-            retryDelay: 100,
-        });
+        if (!fs.existsSync(targetPath)) {
+            return;
+        }
+
+        const remove = (pathToRemove: string) => {
+            chmodRecursive(pathToRemove);
+            fs.rmSync(pathToRemove, {
+                recursive: true,
+                force: true,
+                maxRetries: 60,
+                retryDelay: 250,
+            });
+        };
+
+        try {
+            remove(targetPath);
+        } catch (error: unknown) {
+            const code = (error as NodeJS.ErrnoException | undefined)?.code;
+            if (code !== 'EPERM' && code !== 'EBUSY' && code !== 'ENOTEMPTY') {
+                throw error;
+            }
+
+            const movedPath = `${targetPath}.stale-${Date.now()}-${Math.random()
+                .toString(16)
+                .slice(2)}`;
+            fs.renameSync(targetPath, movedPath);
+            try {
+                remove(movedPath);
+            } catch (secondError: unknown) {
+                const secondCode = (secondError as NodeJS.ErrnoException | undefined)?.code;
+                if (secondCode !== 'EPERM' && secondCode !== 'EBUSY' && secondCode !== 'ENOTEMPTY') {
+                    throw secondError;
+                }
+            }
+        }
     }
 
     function getInjectedLocationValue<T>(
@@ -281,6 +329,40 @@ suite('Command Execution', function () {
         );
     }
 
+    function getWorkspaceInjectionModes(
+        wsConfig: vscode.WorkspaceConfiguration,
+    ): Record<string, unknown> | undefined {
+        return cloneJson(
+            getScopedSettingValue<Record<string, unknown>>(wsConfig, 'metaflow.injection.modes'),
+        );
+    }
+
+    async function useSettingsBackedInstructions(
+        wsFolder: vscode.WorkspaceFolder,
+    ): Promise<Record<string, unknown> | undefined> {
+        const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder.uri);
+        const previousModes = getWorkspaceInjectionModes(wsConfig);
+        await updateConfigAndWait(
+            'metaflow.injection.modes',
+            { ...(previousModes ?? {}), instructions: 'settings' },
+            vscode.ConfigurationTarget.Workspace,
+            wsFolder,
+        );
+        return previousModes;
+    }
+
+    async function restoreInjectionModes(
+        wsFolder: vscode.WorkspaceFolder,
+        previousModes: Record<string, unknown> | undefined,
+    ): Promise<void> {
+        await updateConfigAndWait(
+            'metaflow.injection.modes',
+            previousModes,
+            vscode.ConfigurationTarget.Workspace,
+            wsFolder,
+        );
+    }
+
     async function resetBuiltInCapabilityState(): Promise<void> {
         const windowAny = vscode.window as unknown as {
             showQuickPick: (...items: unknown[]) => Thenable<unknown>;
@@ -432,6 +514,9 @@ suite('Command Execution', function () {
                 },
             },
             activeProfile: 'default',
+            injection: {
+                instructions: 'settings',
+            },
         };
 
         const windowAny = vscode.window as unknown as {
@@ -600,6 +685,9 @@ suite('Command Execution', function () {
                 },
             },
             activeProfile: 'default',
+            injection: {
+                instructions: 'settings',
+            },
         };
 
         const windowAny = vscode.window as unknown as {
@@ -6227,6 +6315,7 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder!,
         );
+        const previousInjectionModes = await useSettingsBackedInstructions(wsFolder!);
         await resetBuiltInCapabilityState();
         await wsConfig.update(
             'chat.instructionsFilesLocations',
@@ -6272,6 +6361,7 @@ suite('Command Execution', function () {
                 undefined,
                 vscode.ConfigurationTarget.Workspace,
             );
+            await restoreInjectionModes(wsFolder!, previousInjectionModes);
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             await vscode.commands.executeCommand('metaflow.refresh');
         }
@@ -6296,6 +6386,7 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder!,
         );
+        const previousInjectionModes = await useSettingsBackedInstructions(wsFolder!);
         await resetBuiltInCapabilityState();
         await wsConfig.update(
             'chat.instructionsFilesLocations',
@@ -6363,6 +6454,7 @@ suite('Command Execution', function () {
                 undefined,
                 vscode.ConfigurationTarget.Workspace,
             );
+            await restoreInjectionModes(wsFolder!, previousInjectionModes);
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             await resetBuiltInCapabilityState();
             await vscode.commands.executeCommand('metaflow.refresh');
@@ -6403,6 +6495,7 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder!,
         );
+        const previousInjectionModes = await useSettingsBackedInstructions(wsFolder!);
         await updateConfigAndWait(
             'chat.instructionsFilesLocations',
             unmanagedInstructionLocations,
@@ -6490,6 +6583,7 @@ suite('Command Execution', function () {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
+            await restoreInjectionModes(wsFolder!, previousInjectionModes);
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             removeDirectoryRecursive(unmanagedRoot);
             await resetBuiltInCapabilityState();
@@ -6527,6 +6621,7 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder!,
         );
+        const previousInjectionModes = await useSettingsBackedInstructions(wsFolder!);
         await updateConfigAndWait(
             'chat.instructionsFilesLocations',
             {
@@ -6598,6 +6693,7 @@ suite('Command Execution', function () {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
+            await restoreInjectionModes(wsFolder!, previousInjectionModes);
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             removeDirectoryRecursive(unmanagedRoot);
             await resetBuiltInCapabilityState();
@@ -6639,6 +6735,7 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder!,
         );
+        const previousInjectionModes = await useSettingsBackedInstructions(wsFolder!);
         await updateConfigAndWait(
             'chat.instructionsFilesLocations',
             unmanagedInstructionLocations,
@@ -6721,6 +6818,7 @@ suite('Command Execution', function () {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
+            await restoreInjectionModes(wsFolder!, previousInjectionModes);
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             removeDirectoryRecursive(unmanagedRoot);
             await resetBuiltInCapabilityState();

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -163,7 +163,19 @@ suite('Command Execution', function () {
             const movedPath = `${targetPath}.stale-${Date.now()}-${Math.random()
                 .toString(16)
                 .slice(2)}`;
-            fs.renameSync(targetPath, movedPath);
+            try {
+                fs.renameSync(targetPath, movedPath);
+            } catch (renameError: unknown) {
+                const renameCode = (renameError as NodeJS.ErrnoException | undefined)?.code;
+                if (
+                    renameCode !== 'EPERM' &&
+                    renameCode !== 'EBUSY' &&
+                    renameCode !== 'ENOTEMPTY'
+                ) {
+                    throw renameError;
+                }
+                return;
+            }
             try {
                 remove(movedPath);
             } catch (secondError: unknown) {
@@ -665,6 +677,8 @@ suite('Command Execution', function () {
         const priorAutoApply = metaflowConfig.inspect<boolean>('autoApply')?.workspaceValue;
         const priorAiMetadataAutoApplyMode =
             metaflowConfig.inspect<string>('aiMetadataAutoApplyMode')?.workspaceValue;
+        const priorInjectionTarget =
+            metaflowConfig.inspect<string>('injection.target')?.workspaceValue;
 
         const configPath = path.join(workspaceRoot, '.metaflow', 'config.jsonc');
         const originalConfig = fs.readFileSync(configPath, 'utf-8');
@@ -713,6 +727,12 @@ suite('Command Execution', function () {
             vscode.ConfigurationTarget.Workspace,
             wsFolder,
         );
+        await updateConfigAndWait(
+            'metaflow.injection.target',
+            'workspace',
+            vscode.ConfigurationTarget.Workspace,
+            wsFolder,
+        );
         await metaflowConfig.update('autoApply', false, vscode.ConfigurationTarget.Workspace);
         await metaflowConfig.update(
             'aiMetadataAutoApplyMode',
@@ -735,17 +755,15 @@ suite('Command Execution', function () {
 
             await waitFor(() => {
                 const freshConfig = vscode.workspace.getConfiguration(undefined, wsFolder.uri);
-                const instructionLocations = getScopedSettingValue<Record<string, boolean>>(
-                    freshConfig,
-                    'chat.instructionsFilesLocations',
+                const instructionLocations = getInjectedLocationValue(
+                    freshConfig.inspect<Record<string, boolean>>('chat.instructionsFilesLocations'),
                 );
                 return !!instructionLocations && Object.keys(instructionLocations).length > 0;
             });
 
             const freshConfig = vscode.workspace.getConfiguration(undefined, wsFolder.uri);
-            const instructionLocations = getScopedSettingValue<Record<string, boolean>>(
-                freshConfig,
-                'chat.instructionsFilesLocations',
+            const instructionLocations = getInjectedLocationValue(
+                freshConfig.inspect<Record<string, boolean>>('chat.instructionsFilesLocations'),
             );
             assert.ok(
                 instructionLocations && Object.keys(instructionLocations).length > 0,
@@ -762,6 +780,12 @@ suite('Command Execution', function () {
                 'aiMetadataAutoApplyMode',
                 priorAiMetadataAutoApplyMode,
                 vscode.ConfigurationTarget.Workspace,
+            );
+            await updateConfigAndWait(
+                'metaflow.injection.target',
+                priorInjectionTarget,
+                vscode.ConfigurationTarget.Workspace,
+                wsFolder,
             );
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
             removeDirectoryRecursive(repoRoot);

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -118,19 +118,24 @@ suite('Command Execution', function () {
         return JSON.parse(JSON.stringify(value)) as T;
     }
 
+    function isIgnorableCleanupError(error: unknown): boolean {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        return code === 'EPERM' || code === 'EBUSY' || code === 'ENOTEMPTY' || code === 'ENOENT';
+    }
+
     function chmodRecursive(targetPath: string): void {
-        if (!fs.existsSync(targetPath)) {
-            return;
-        }
-
-        const stat = fs.lstatSync(targetPath);
-        if (stat.isDirectory()) {
-            for (const entry of fs.readdirSync(targetPath)) {
-                chmodRecursive(path.join(targetPath, entry));
-            }
-        }
-
         try {
+            if (!fs.existsSync(targetPath)) {
+                return;
+            }
+
+            const stat = fs.lstatSync(targetPath);
+            if (stat.isDirectory()) {
+                for (const entry of fs.readdirSync(targetPath)) {
+                    chmodRecursive(path.join(targetPath, entry));
+                }
+            }
+
             fs.chmodSync(targetPath, 0o777);
         } catch {
             // Best-effort cleanup support for transient Windows file locks.
@@ -155,8 +160,7 @@ suite('Command Execution', function () {
         try {
             remove(targetPath);
         } catch (error: unknown) {
-            const code = (error as NodeJS.ErrnoException | undefined)?.code;
-            if (code !== 'EPERM' && code !== 'EBUSY' && code !== 'ENOTEMPTY') {
+            if (!isIgnorableCleanupError(error)) {
                 throw error;
             }
 
@@ -166,12 +170,7 @@ suite('Command Execution', function () {
             try {
                 fs.renameSync(targetPath, movedPath);
             } catch (renameError: unknown) {
-                const renameCode = (renameError as NodeJS.ErrnoException | undefined)?.code;
-                if (
-                    renameCode !== 'EPERM' &&
-                    renameCode !== 'EBUSY' &&
-                    renameCode !== 'ENOTEMPTY'
-                ) {
+                if (!isIgnorableCleanupError(renameError)) {
                     throw renameError;
                 }
                 return;
@@ -179,12 +178,7 @@ suite('Command Execution', function () {
             try {
                 remove(movedPath);
             } catch (secondError: unknown) {
-                const secondCode = (secondError as NodeJS.ErrnoException | undefined)?.code;
-                if (
-                    secondCode !== 'EPERM' &&
-                    secondCode !== 'EBUSY' &&
-                    secondCode !== 'ENOTEMPTY'
-                ) {
+                if (!isIgnorableCleanupError(secondError)) {
                     throw secondError;
                 }
             }
@@ -349,7 +343,7 @@ suite('Command Execution', function () {
         wsConfig: vscode.WorkspaceConfiguration,
     ): Record<string, unknown> | undefined {
         return cloneJson(
-            getScopedSettingValue<Record<string, unknown>>(wsConfig, 'metaflow.injection.modes'),
+            wsConfig.inspect<Record<string, unknown>>('metaflow.injection.modes')?.workspaceValue,
         );
     }
 
@@ -683,30 +677,7 @@ suite('Command Execution', function () {
         const configPath = path.join(workspaceRoot, '.metaflow', 'config.jsonc');
         const originalConfig = fs.readFileSync(configPath, 'utf-8');
 
-        const repoRoot = path.join(workspaceRoot, '.ai', 'settings-only-repo');
-        const layerInstructionsDir = path.join(repoRoot, 'settings-only', 'instructions');
-        removeDirectoryRecursive(repoRoot);
-        fs.mkdirSync(layerInstructionsDir, { recursive: true });
-        fs.writeFileSync(
-            path.join(layerInstructionsDir, 'settings-only.instructions.md'),
-            '# settings-only\n',
-            'utf-8',
-        );
-
-        const settingsOnlyConfig = {
-            metadataRepos: [{ id: 'settings', localPath: '.ai/settings-only-repo', enabled: true }],
-            layerSources: [{ repoId: 'settings', path: 'settings-only', enabled: true }],
-            filters: { include: ['**'], exclude: [] },
-            profiles: {
-                default: {
-                    enable: ['**/*'],
-                },
-            },
-            activeProfile: 'default',
-            injection: {
-                instructions: 'settings',
-            },
-        };
+        const settingsOnlyConfig = createSettingsBackedWorkspaceConfig();
 
         const windowAny = vscode.window as unknown as {
             showInformationMessage: (...items: unknown[]) => Thenable<string | undefined>;
@@ -788,7 +759,6 @@ suite('Command Execution', function () {
                 wsFolder,
             );
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
-            removeDirectoryRecursive(repoRoot);
             await vscode.commands.executeCommand('metaflow.refresh');
         }
     });

--- a/src/src/test/integration/commands.test.ts
+++ b/src/src/test/integration/commands.test.ts
@@ -671,13 +671,34 @@ suite('Command Execution', function () {
         const priorAutoApply = metaflowConfig.inspect<boolean>('autoApply')?.workspaceValue;
         const priorAiMetadataAutoApplyMode =
             metaflowConfig.inspect<string>('aiMetadataAutoApplyMode')?.workspaceValue;
-        const priorInjectionTarget =
-            metaflowConfig.inspect<string>('injection.target')?.workspaceValue;
 
         const configPath = path.join(workspaceRoot, '.metaflow', 'config.jsonc');
         const originalConfig = fs.readFileSync(configPath, 'utf-8');
 
-        const settingsOnlyConfig = createSettingsBackedWorkspaceConfig();
+        const repoRoot = path.join(workspaceRoot, '.ai', 'settings-only-repo');
+        const layerInstructionsDir = path.join(repoRoot, 'settings-only', 'instructions');
+        removeDirectoryRecursive(repoRoot);
+        fs.mkdirSync(layerInstructionsDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(layerInstructionsDir, 'settings-only.instructions.md'),
+            '# settings-only\n',
+            'utf-8',
+        );
+
+        const settingsOnlyConfig = {
+            metadataRepos: [{ id: 'settings', localPath: '.ai/settings-only-repo', enabled: true }],
+            layerSources: [{ repoId: 'settings', path: 'settings-only', enabled: true }],
+            filters: { include: ['**'], exclude: [] },
+            profiles: {
+                default: {
+                    enable: ['**/*'],
+                },
+            },
+            activeProfile: 'default',
+            injection: {
+                instructions: 'settings',
+            },
+        };
 
         const windowAny = vscode.window as unknown as {
             showInformationMessage: (...items: unknown[]) => Thenable<string | undefined>;
@@ -692,27 +713,20 @@ suite('Command Execution', function () {
             return undefined;
         };
 
-        await updateConfigAndWait(
-            'chat.instructionsFilesLocations',
-            undefined,
-            vscode.ConfigurationTarget.Workspace,
-            wsFolder,
-        );
-        await updateConfigAndWait(
-            'metaflow.injection.target',
-            'workspace',
-            vscode.ConfigurationTarget.Workspace,
-            wsFolder,
-        );
-        await metaflowConfig.update('autoApply', false, vscode.ConfigurationTarget.Workspace);
-        await metaflowConfig.update(
-            'aiMetadataAutoApplyMode',
-            'off',
-            vscode.ConfigurationTarget.Workspace,
-        );
-
         try {
             fs.writeFileSync(configPath, JSON.stringify(settingsOnlyConfig, null, 2), 'utf-8');
+            await updateConfigAndWait(
+                'chat.instructionsFilesLocations',
+                undefined,
+                vscode.ConfigurationTarget.Workspace,
+                wsFolder,
+            );
+            await metaflowConfig.update('autoApply', false, vscode.ConfigurationTarget.Workspace);
+            await metaflowConfig.update(
+                'aiMetadataAutoApplyMode',
+                'off',
+                vscode.ConfigurationTarget.Workspace,
+            );
 
             await vscode.commands.executeCommand('metaflow.refresh', { skipAutoApply: true });
             applyMessages.length = 0;
@@ -752,13 +766,8 @@ suite('Command Execution', function () {
                 priorAiMetadataAutoApplyMode,
                 vscode.ConfigurationTarget.Workspace,
             );
-            await updateConfigAndWait(
-                'metaflow.injection.target',
-                priorInjectionTarget,
-                vscode.ConfigurationTarget.Workspace,
-                wsFolder,
-            );
             fs.writeFileSync(configPath, originalConfig, 'utf-8');
+            removeDirectoryRecursive(repoRoot);
             await vscode.commands.executeCommand('metaflow.refresh');
         }
     });

--- a/src/src/test/integration/governanceCommands.test.ts
+++ b/src/src/test/integration/governanceCommands.test.ts
@@ -405,7 +405,10 @@ suite('Governance command enforcement', () => {
             });
 
             const updatedConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
-                profiles?: Record<string, { layerOverrides?: Array<{ path: string; enabled?: boolean }> }>;
+                profiles?: Record<
+                    string,
+                    { layerOverrides?: Array<{ path: string; enabled?: boolean }> }
+                >;
             };
             assert.strictEqual(
                 updatedConfig.profiles?.default?.layerOverrides,
@@ -414,7 +417,9 @@ suite('Governance command enforcement', () => {
             );
             assert.ok(
                 messages.errors.some((message) =>
-                    message.includes('[GOVERNANCE_REQUIRED_CAPABILITY_MISSING::primary::company/core]'),
+                    message.includes(
+                        '[GOVERNANCE_REQUIRED_CAPABILITY_MISSING::primary::company/core]',
+                    ),
                 ),
                 `Expected stable governance ids in error message, got: ${messages.errors.join('\n')}`,
             );
@@ -488,7 +493,10 @@ suite('Governance command enforcement', () => {
             });
 
             const updatedConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
-                profiles?: Record<string, { layerOverrides?: Array<{ path: string; enabled?: boolean }> }>;
+                profiles?: Record<
+                    string,
+                    { layerOverrides?: Array<{ path: string; enabled?: boolean }> }
+                >;
             };
             assert.strictEqual(
                 updatedConfig.profiles?.default?.layerOverrides,
@@ -522,8 +530,9 @@ suite('Governance command enforcement', () => {
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
         const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
-        const previousMode = wsConfig.inspect<string>('metaflow.aiMetadataAutoApplyMode')
-            ?.workspaceValue;
+        const previousMode = wsConfig.inspect<string>(
+            'metaflow.aiMetadataAutoApplyMode',
+        )?.workspaceValue;
         const previousInjectionModes = wsConfig.inspect<Record<string, unknown>>(
             'metaflow.injection.modes',
         )?.workspaceValue;
@@ -645,8 +654,9 @@ suite('Governance command enforcement', () => {
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
         const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
-        const previousMode = wsConfig.inspect<string>('metaflow.aiMetadataAutoApplyMode')
-            ?.workspaceValue;
+        const previousMode = wsConfig.inspect<string>(
+            'metaflow.aiMetadataAutoApplyMode',
+        )?.workspaceValue;
         const previousInjectionModes = wsConfig.inspect<Record<string, unknown>>(
             'metaflow.injection.modes',
         )?.workspaceValue;
@@ -823,7 +833,9 @@ suite('Governance command enforcement', () => {
             }>('metaflow.getDiagnosticsSnapshot');
             assert.strictEqual(beforeSnapshot?.governance.compliance?.status, 'non-compliant');
             assert.deepStrictEqual(
-                beforeSnapshot?.governance.compliance?.violations.map((violation) => violation.id) ?? [],
+                beforeSnapshot?.governance.compliance?.violations.map(
+                    (violation) => violation.id,
+                ) ?? [],
                 ['GOVERNANCE_REQUIRED_CAPABILITY_MISSING::primary::standards/sdlc'],
             );
 
@@ -857,7 +869,8 @@ suite('Governance command enforcement', () => {
             }>('metaflow.getDiagnosticsSnapshot');
             assert.strictEqual(afterSnapshot?.governance.compliance?.status, 'compliant');
             assert.deepStrictEqual(
-                afterSnapshot?.governance.compliance?.violations.map((violation) => violation.id) ?? [],
+                afterSnapshot?.governance.compliance?.violations.map((violation) => violation.id) ??
+                    [],
                 [],
             );
             assert.deepStrictEqual(

--- a/src/src/test/integration/governanceCommands.test.ts
+++ b/src/src/test/integration/governanceCommands.test.ts
@@ -521,8 +521,12 @@ suite('Governance command enforcement', () => {
         const wsFolder = vscode.workspace.workspaceFolders?.[0];
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
+        const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
         const previousMode = wsConfig.inspect<string>('metaflow.aiMetadataAutoApplyMode')
             ?.workspaceValue;
+        const previousInjectionModes = wsConfig.inspect<Record<string, unknown>>(
+            'metaflow.injection.modes',
+        )?.workspaceValue;
         const configPath = path.join(workspaceRoot, '.metaflow', 'config.jsonc');
         const originalConfig = fs.readFileSync(configPath, 'utf-8');
         const originalGovernanceExists = fs.existsSync(governancePath);
@@ -537,6 +541,11 @@ suite('Governance command enforcement', () => {
                 'off',
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
+            );
+            await metaflowConfig.update(
+                'injection.modes',
+                { instructions: 'settings' },
+                vscode.ConfigurationTarget.Workspace,
             );
             await resetBuiltInCapabilityState();
             await wsConfig.update(
@@ -608,6 +617,11 @@ suite('Governance command enforcement', () => {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
+            await metaflowConfig.update(
+                'injection.modes',
+                previousInjectionModes,
+                vscode.ConfigurationTarget.Workspace,
+            );
             await wsConfig.update(
                 'chat.instructionsFilesLocations',
                 undefined,
@@ -630,8 +644,12 @@ suite('Governance command enforcement', () => {
         const wsFolder = vscode.workspace.workspaceFolders?.[0];
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
+        const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
         const previousMode = wsConfig.inspect<string>('metaflow.aiMetadataAutoApplyMode')
             ?.workspaceValue;
+        const previousInjectionModes = wsConfig.inspect<Record<string, unknown>>(
+            'metaflow.injection.modes',
+        )?.workspaceValue;
         const configPath = path.join(workspaceRoot, '.metaflow', 'config.jsonc');
         const originalConfig = fs.readFileSync(configPath, 'utf-8');
         const originalGovernanceExists = fs.existsSync(governancePath);
@@ -646,6 +664,11 @@ suite('Governance command enforcement', () => {
                 'off',
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
+            );
+            await metaflowConfig.update(
+                'injection.modes',
+                { instructions: 'settings' },
+                vscode.ConfigurationTarget.Workspace,
             );
             await resetBuiltInCapabilityState();
             await wsConfig.update(
@@ -717,6 +740,11 @@ suite('Governance command enforcement', () => {
                 previousMode,
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
+            );
+            await metaflowConfig.update(
+                'injection.modes',
+                previousInjectionModes,
+                vscode.ConfigurationTarget.Workspace,
             );
             await wsConfig.update(
                 'chat.instructionsFilesLocations',

--- a/src/src/test/integration/governanceCommands.test.ts
+++ b/src/src/test/integration/governanceCommands.test.ts
@@ -529,7 +529,6 @@ suite('Governance command enforcement', () => {
         const wsFolder = vscode.workspace.workspaceFolders?.[0];
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
-        const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
         const previousMode = wsConfig.inspect<string>(
             'metaflow.aiMetadataAutoApplyMode',
         )?.workspaceValue;
@@ -551,10 +550,11 @@ suite('Governance command enforcement', () => {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
-            await metaflowConfig.update(
-                'injection.modes',
+            await updateConfigAndWait(
+                'metaflow.injection.modes',
                 { instructions: 'settings' },
                 vscode.ConfigurationTarget.Workspace,
+                wsFolder!,
             );
             await resetBuiltInCapabilityState();
             await wsConfig.update(
@@ -626,10 +626,11 @@ suite('Governance command enforcement', () => {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
-            await metaflowConfig.update(
-                'injection.modes',
+            await updateConfigAndWait(
+                'metaflow.injection.modes',
                 previousInjectionModes,
                 vscode.ConfigurationTarget.Workspace,
+                wsFolder!,
             );
             await wsConfig.update(
                 'chat.instructionsFilesLocations',
@@ -653,7 +654,6 @@ suite('Governance command enforcement', () => {
         const wsFolder = vscode.workspace.workspaceFolders?.[0];
         assert.ok(wsFolder, 'Workspace folder should be available');
         const wsConfig = vscode.workspace.getConfiguration(undefined, wsFolder!.uri);
-        const metaflowConfig = vscode.workspace.getConfiguration('metaflow', wsFolder!.uri);
         const previousMode = wsConfig.inspect<string>(
             'metaflow.aiMetadataAutoApplyMode',
         )?.workspaceValue;
@@ -675,10 +675,11 @@ suite('Governance command enforcement', () => {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
-            await metaflowConfig.update(
-                'injection.modes',
+            await updateConfigAndWait(
+                'metaflow.injection.modes',
                 { instructions: 'settings' },
                 vscode.ConfigurationTarget.Workspace,
+                wsFolder!,
             );
             await resetBuiltInCapabilityState();
             await wsConfig.update(
@@ -751,10 +752,11 @@ suite('Governance command enforcement', () => {
                 vscode.ConfigurationTarget.Workspace,
                 wsFolder!,
             );
-            await metaflowConfig.update(
-                'injection.modes',
+            await updateConfigAndWait(
+                'metaflow.injection.modes',
                 previousInjectionModes,
                 vscode.ConfigurationTarget.Workspace,
+                wsFolder!,
             );
             await wsConfig.update(
                 'chat.instructionsFilesLocations',

--- a/src/src/test/unit/commandHandlersConfigUpdateConsent.test.ts
+++ b/src/src/test/unit/commandHandlersConfigUpdateConsent.test.ts
@@ -21,7 +21,7 @@ suite('Command handler config update consent', () => {
         const source = readCommandHandlersSource();
         const refreshUpdateBlock = sourceSlice(
             source,
-            'const shouldPersistConfig = await confirmConfigUpdate(',
+            'const shouldPersistConfig = autoAcceptRefreshUpdates',
             'state.config = result.config;',
         );
 
@@ -43,6 +43,34 @@ suite('Command handler config update consent', () => {
         );
         assert.match(confirmHelper, /'Open Config'/);
         assert.match(confirmHelper, /'Later'/);
+    });
+
+    test('test-mode refresh accepts pending updates without opening modal dialogs', () => {
+        const source = readCommandHandlersSource();
+        const refreshOptionsBlock = sourceSlice(
+            source,
+            'const refreshOptions = extractRefreshCommandOptions(arg);',
+            'const pendingCapabilityPluginMetadataDirtyVersion',
+        );
+
+        assert.match(refreshOptionsBlock, /context\.extensionMode === vscode\.ExtensionMode\.Test/);
+        assert.match(refreshOptionsBlock, /refreshOptions\.nonInteractive === true/);
+
+        const refreshUpdateBlock = sourceSlice(
+            source,
+            'const shouldPersistConfig = autoAcceptRefreshUpdates',
+            'if (shouldPersistConfig && capabilityRepairPreview) {'
+        );
+        assert.match(refreshUpdateBlock, /autoAcceptRefreshUpdates\s+\? true/);
+        assert.match(refreshUpdateBlock, /suppressRefreshUpdatePrompts\s+\? false/);
+
+        const builtInRepairBlock = sourceSlice(
+            source,
+            'const shouldUpdateBuiltInState = autoAcceptRefreshUpdates',
+            'if (shouldUpdateBuiltInState) {'
+        );
+        assert.match(builtInRepairBlock, /autoAcceptRefreshUpdates\s+\? true/);
+        assert.match(builtInRepairBlock, /suppressRefreshUpdatePrompts\s+\? false/);
     });
 
     test('declining capability repair preserves the previous identity snapshot', () => {
@@ -70,7 +98,7 @@ suite('Command handler config update consent', () => {
 
         assert.match(
             builtInRepairBlock,
-            /const shouldUpdateBuiltInState = await confirmBuiltInCapabilityStateUpdate\(/,
+            /const shouldUpdateBuiltInState = autoAcceptRefreshUpdates[\s\S]*await confirmBuiltInCapabilityStateUpdate\(/,
         );
         assert.match(
             builtInRepairBlock,

--- a/src/src/test/unit/commandHelpers.test.ts
+++ b/src/src/test/unit/commandHelpers.test.ts
@@ -357,6 +357,7 @@ suite('Command Helpers', () => {
                 skipRepoSync: undefined,
                 skipSettingsInjection: undefined,
                 preferStateConfig: undefined,
+                nonInteractive: undefined,
                 forceDiscovery: false,
                 forceDiscoveryRepoId: 'repo-a',
             },
@@ -373,19 +374,24 @@ suite('Command Helpers', () => {
                 skipRepoSync: undefined,
                 skipSettingsInjection: undefined,
                 preferStateConfig: undefined,
+                nonInteractive: undefined,
                 forceDiscovery: undefined,
                 forceDiscoveryRepoId: undefined,
             },
         );
-        assert.deepStrictEqual(extractRefreshCommandOptions({ skipRepoSync: true }), {
+        assert.deepStrictEqual(
+            extractRefreshCommandOptions({ skipRepoSync: true, nonInteractive: true }),
+            {
             skipAutoApply: undefined,
             skipBuiltInAutoApply: undefined,
             skipRepoSync: true,
             skipSettingsInjection: undefined,
             preferStateConfig: undefined,
+            nonInteractive: true,
             forceDiscovery: undefined,
             forceDiscoveryRepoId: undefined,
-        });
+            },
+        );
 
         assert.deepStrictEqual(extractApplyCommandOptions({ skipRefresh: true }), {
             skipRefresh: true,

--- a/src/src/test/unit/commandHelpers.test.ts
+++ b/src/src/test/unit/commandHelpers.test.ts
@@ -382,14 +382,14 @@ suite('Command Helpers', () => {
         assert.deepStrictEqual(
             extractRefreshCommandOptions({ skipRepoSync: true, nonInteractive: true }),
             {
-            skipAutoApply: undefined,
-            skipBuiltInAutoApply: undefined,
-            skipRepoSync: true,
-            skipSettingsInjection: undefined,
-            preferStateConfig: undefined,
-            nonInteractive: true,
-            forceDiscovery: undefined,
-            forceDiscoveryRepoId: undefined,
+                skipAutoApply: undefined,
+                skipBuiltInAutoApply: undefined,
+                skipRepoSync: true,
+                skipSettingsInjection: undefined,
+                preferStateConfig: undefined,
+                nonInteractive: true,
+                forceDiscovery: undefined,
+                forceDiscoveryRepoId: undefined,
             },
         );
 


### PR DESCRIPTION
Summary
- Stabilizes the settings-only apply integration test by using a real included settings-backed instruction fixture and fresh VS Code configuration reads.
- Adds a Changesets entry for the 0.3.0 preview release lane.

Validation
- npm -C public/metaflow run gate:quick
- npm -C public/metaflow run gate:integration

Expected state
- Merge to develop first.
- Promote the intended release candidate to main only after reviewing the broader develop-to-main delta.
- Let the Version Packages workflow create the actual 0.3.0 version PR once the release candidate reaches main.