### PR TITLE
fix(gui): seed golden config for batched tests

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -28,7 +28,11 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "workspaceContains:**/.metaflow/config.jsonc"
+    "workspaceContains:**/.metaflow/config.jsonc",
+    "onView:metaflow-config",
+    "onView:metaflow-profiles",
+    "onView:metaflow-layers",
+    "onView:metaflow-files"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/scripts/run-gui-batched.mjs
+++ b/src/scripts/run-gui-batched.mjs
@@ -19,7 +19,7 @@
  * are downloaded on first run and reused thereafter.
  */
 import { spawnSync } from 'node:child_process';
-import { readdirSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,6 +34,9 @@ const extestCli = require.resolve('vscode-extension-tester/out/cli.js');
 const STORAGE = '.vscode-test/gui';
 const EXTENSIONS = '.vscode-test/gui/extensions';
 const VSIX = 'metaflow-test.vsix';
+const TEST_WORKSPACE = 'test-workspace';
+const LIVE_CONFIG = path.join(srcRoot, TEST_WORKSPACE, '.metaflow', 'config.jsonc');
+const GOLDEN_CONFIG = path.join(srcRoot, TEST_WORKSPACE, '.metaflow', 'config.golden.jsonc');
 
 const batchSize = Math.max(1, Number(process.env.GUI_BATCH_SIZE ?? '6'));
 const prefixes = process.argv.slice(2);
@@ -49,6 +52,17 @@ function runExtest(args, label) {
     process.stdout.write(out);
     return { status: res.status ?? 1, out };
 }
+
+function seedGoldenConfig() {
+    mkdirSync(path.dirname(GOLDEN_CONFIG), { recursive: true });
+    copyFileSync(LIVE_CONFIG, GOLDEN_CONFIG);
+}
+
+function restoreLiveConfigFromGolden() {
+    copyFileSync(GOLDEN_CONFIG, LIVE_CONFIG);
+}
+
+seedGoldenConfig();
 
 // ── Setup: download VS Code + chromedriver (idempotent) and install the VSIX ──
 const setupSteps = [
@@ -87,17 +101,23 @@ let totalFail = 0;
 const failedBatches = [];
 
 for (const [idx, batch] of batches.entries()) {
+    restoreLiveConfigFromGolden();
     const files = batch.map((f) => path.posix.join('out/test/gui', f));
     const label = `batch ${idx + 1}/${batches.length}: ${batch.join(', ')}`;
     const { status, out } = runExtest(
         [
             'run-tests',
             ...files,
-            '-s', STORAGE,
-            '-e', EXTENSIONS,
-            '-r', 'test-workspace',
-            '-m', '.mocharc-gui.js',
-            '-o', '.vscode-test-gui-settings.json',
+            '-s',
+            STORAGE,
+            '-e',
+            EXTENSIONS,
+            '-r',
+            TEST_WORKSPACE,
+            '-m',
+            '.mocharc-gui.js',
+            '-o',
+            '.vscode-test-gui-settings.json',
         ],
         label,
     );
@@ -112,7 +132,7 @@ for (const [idx, batch] of batches.entries()) {
 
 console.log(
     `\n=== GUI batched summary: ${totalPass} passing, ${totalFail} failing ` +
-    `across ${batches.length} batch(es) of ${batchSize} ===`,
+        `across ${batches.length} batch(es) of ${batchSize} ===`,
 );
 if (failedBatches.length > 0) {
     console.log('Batches with failures:');

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -298,10 +298,12 @@ interface ManagedSettingsState {
     managedPluginUris?: string[];
 }
 
-function getWorkspace(): vscode.WorkspaceFolder | undefined {
+function getWorkspace(options?: { showError?: boolean }): vscode.WorkspaceFolder | undefined {
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
-        vscode.window.showErrorMessage('MetaFlow: No workspace folder open.');
+        if (options?.showError !== false) {
+            vscode.window.showErrorMessage('MetaFlow: No workspace folder open.');
+        }
         return undefined;
     }
 
@@ -423,6 +425,25 @@ function isPathWithin(candidatePath: string, rootPath: string): boolean {
     );
 }
 
+const copilotPluginSettingsUpdateQueues = new Map<string, Promise<void>>();
+
+async function enqueueCopilotPluginSettingsUpdate(
+    settingsPath: string,
+    update: () => Promise<void>,
+): Promise<void> {
+    const previous = copilotPluginSettingsUpdateQueues.get(settingsPath) ?? Promise.resolve();
+    const next = previous.then(update, update);
+    copilotPluginSettingsUpdateQueues.set(
+        settingsPath,
+        next.finally(() => {
+            if (copilotPluginSettingsUpdateQueues.get(settingsPath) === next) {
+                copilotPluginSettingsUpdateQueues.delete(settingsPath);
+            }
+        }),
+    );
+    await next;
+}
+
 function filterSettingsEligibleEffectiveFiles(
     effectiveFiles: EffectiveFile[],
     builtInCapability: BuiltInCapabilityRuntimeState,
@@ -454,6 +475,22 @@ async function updateManagedCopilotPluginSettings(
     nextManagedPluginUris: string[],
 ): Promise<void> {
     const settingsPath = getCopilotPluginSettingsPath(workspaceRoot);
+    await enqueueCopilotPluginSettingsUpdate(settingsPath, async () => {
+        await updateManagedCopilotPluginSettingsFile(
+            workspaceRoot,
+            settingsPath,
+            previousManagedPluginUris,
+            nextManagedPluginUris,
+        );
+    });
+}
+
+async function updateManagedCopilotPluginSettingsFile(
+    workspaceRoot: string,
+    settingsPath: string,
+    previousManagedPluginUris: string[],
+    nextManagedPluginUris: string[],
+): Promise<void> {
     const normalizedPrevious = normalizeManagedPluginUris(previousManagedPluginUris);
     const normalizedNext = normalizeManagedPluginUris(nextManagedPluginUris);
 
@@ -467,36 +504,39 @@ async function updateManagedCopilotPluginSettings(
         }
     }
 
+    let rewriteExistingFromScratch = false;
+
     const nextEnabledPlugins = (() => {
         const enabledPlugins: Record<string, boolean> = {};
 
         if (existing !== undefined) {
-            const parseErrors: jsonc.ParseError[] = [];
-            const parsed = jsonc.parse(existing, parseErrors, {
-                allowTrailingComma: true,
-                disallowComments: false,
-            });
+            if (existing.trim().length === 0) {
+                rewriteExistingFromScratch = true;
+            } else {
+                const parseErrors: jsonc.ParseError[] = [];
+                const parsed = jsonc.parse(existing, parseErrors, {
+                    allowTrailingComma: true,
+                    disallowComments: false,
+                });
 
-            if (parseErrors.length > 0) {
-                const first = parseErrors[0];
-                throw new Error(
-                    `${COPILOT_PLUGIN_SETTINGS_RELATIVE_PATH} could not be parsed near offset ${first.offset}.`,
-                );
-            }
-
-            if (
-                parsed !== undefined &&
-                (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
-            ) {
-                throw new Error(
-                    `${COPILOT_PLUGIN_SETTINGS_RELATIVE_PATH} must contain a top-level JSON object.`,
-                );
-            }
-
-            const parsedObject = (parsed ?? {}) as Record<string, unknown>;
-            if (isBooleanRecord(parsedObject.enabledPlugins)) {
-                for (const [pluginUri, enabled] of Object.entries(parsedObject.enabledPlugins)) {
-                    enabledPlugins[pluginUri] = enabled;
+                if (parseErrors.length > 0) {
+                    // This file is machine-local and fully managed for the enabledPlugins key.
+                    // Heal blank or truncated JSON instead of failing the entire refresh/apply path.
+                    rewriteExistingFromScratch = true;
+                } else if (
+                    parsed !== undefined &&
+                    (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+                ) {
+                    rewriteExistingFromScratch = true;
+                } else {
+                    const parsedObject = (parsed ?? {}) as Record<string, unknown>;
+                    if (isBooleanRecord(parsedObject.enabledPlugins)) {
+                        for (const [pluginUri, enabled] of Object.entries(
+                            parsedObject.enabledPlugins,
+                        )) {
+                            enabledPlugins[pluginUri] = enabled;
+                        }
+                    }
                 }
             }
         }
@@ -533,6 +573,18 @@ async function updateManagedCopilotPluginSettings(
             JSON.stringify({ enabledPlugins: nextEnabledPlugins }, null, 2) + '\n',
             'utf-8',
         );
+        return;
+    }
+
+    if (rewriteExistingFromScratch) {
+        const recoveredContent =
+            Object.keys(nextEnabledPlugins).length > 0
+                ? JSON.stringify({ enabledPlugins: nextEnabledPlugins }, null, 2) + '\n'
+                : '{}\n';
+
+        await ensureLocalGitExcludeEntry(workspaceRoot, COPILOT_PLUGIN_SETTINGS_RELATIVE_PATH);
+        await fsp.mkdir(path.dirname(settingsPath), { recursive: true });
+        await fsp.writeFile(settingsPath, recoveredContent, 'utf-8');
         return;
     }
 
@@ -5051,8 +5103,11 @@ export function registerCommands(
     // ── metaflow.refresh ───────────────────────────────────────────
     context.subscriptions.push(
         vscode.commands.registerCommand('metaflow.refresh', async (arg?: unknown) => {
-            const ws = getWorkspace();
+            const ws = getWorkspace({ showError: false });
             if (!ws) {
+                logWarn('Refresh skipped: no workspace folder is open.');
+                state.isLoading = false;
+                state.onDidChange.fire();
                 return;
             }
 
@@ -5149,6 +5204,11 @@ export function registerCommands(
                     refreshOptions.forceDiscoveryRepoId,
                     { enableDiscovery: true },
                 );
+                state.config = result.config;
+                state.configPath = result.configPath;
+                state.activeProfile = result.config.activeProfile;
+                state.isLoading = false;
+                state.onDidChange.fire();
                 let capabilityRepairPreview: CapabilityIdentityDriftRepairPreview | undefined;
                 try {
                     capabilityRepairPreview = previewCapabilityIdentityDriftRepair(
@@ -5251,9 +5311,6 @@ export function registerCommands(
                         );
                     }
                 }
-                state.config = result.config;
-                state.configPath = result.configPath;
-                state.activeProfile = result.config.activeProfile;
                 state.builtInCapability = await loadBuiltInCapabilityRuntimeState(context);
                 state.builtInCapability = await syncTrackedSynchronizedBuiltInCapabilityFiles(
                     context,

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -616,14 +616,29 @@ export function activate(context: vscode.ExtensionContext): void {
     // Set context for keybindings/menus
     vscode.commands.executeCommand('setContext', 'metaflow.active', true);
 
-    if (!isTestMode) {
-        // Auto-refresh on activation, then offer promotion for local git repos missing remote URLs.
-        void (async () => {
-            await vscode.commands.executeCommand('metaflow.refresh');
+    const activationRefreshOptions = { skipRepoSync: true, nonInteractive: true };
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeWorkspaceFolders((event) => {
+            if (event.added.length === 0) {
+                return;
+            }
+            syncRepoUpdateSchedulerLifecycle();
+            void vscode.commands.executeCommand('metaflow.refresh', activationRefreshOptions);
+        }),
+    );
+
+    // Auto-refresh on activation so contributed TreeViews leave their loading state.
+    // Startup must never block on modal update prompts; test hosts also skip repo sync.
+    void (async () => {
+        await vscode.commands.executeCommand('metaflow.refresh', activationRefreshOptions);
+        if (!isTestMode) {
             await vscode.commands.executeCommand('metaflow.offerGitRemotePromotion');
             await vscode.commands.executeCommand('metaflow.offerGitIgnoreStateConfiguration');
-        })();
+        }
+    })();
 
+    if (!isTestMode) {
         const schedulerLifecycle = createRepoUpdateSchedulerLifecycleController({
             workspaceHasConfig: workspaceHasMetaFlowConfig,
             createScheduler: () => {

--- a/src/src/test/gui/helpers/metaflowGuiHelpers.ts
+++ b/src/src/test/gui/helpers/metaflowGuiHelpers.ts
@@ -300,14 +300,28 @@ export async function openMetaFlowSidebar(): Promise<SideBarView> {
         return Boolean(control);
     }, STARTUP_TIMEOUT);
     assert.ok(control, 'MetaFlow activity bar entry not found');
+    let sideBar: SideBarView;
     try {
-        return (await control.openView()) as SideBarView;
+        sideBar = (await control.openView()) as SideBarView;
     } catch {
         // A modal backdrop likely intercepted the click — dismiss and retry once.
         await dismissWelcomeOverlay();
         await sleep(300);
-        return (await control.openView()) as SideBarView;
+        sideBar = (await control.openView()) as SideBarView;
     }
+
+    // CI can render the contributed view containers before the activation-time
+    // refresh has populated tree state. Run the command explicitly once after
+    // opening the sidebar so tests wait on real data, not VS Code activation
+    // event ordering.
+    try {
+        await new Workbench().executeCommand('MetaFlow: Refresh');
+    } catch {
+        // If the command palette races command registration, the following
+        // section readiness wait still provides a useful failure point.
+    }
+
+    return sideBar;
 }
 
 /**
@@ -331,13 +345,7 @@ export async function expandSection(section: ViewSection): Promise<void> {
  */
 export async function getVisibleItemTexts(section: ViewSection): Promise<string[]> {
     const items = await section.getVisibleItems();
-    return Promise.all(
-        items.map((item) =>
-            (item as TreeItem)
-                .getText()
-                .catch(() => ''),
-        ),
-    );
+    return Promise.all(items.map((item) => (item as TreeItem).getText().catch(() => '')));
 }
 
 /**
@@ -378,13 +386,20 @@ export async function waitForSectionReady(
     timeoutMs = WAIT_TIMEOUT,
 ): Promise<void> {
     await expandSection(section);
+    let latestTexts: string[] = [];
     await waitFor(async () => {
-        const texts = await getVisibleItemTexts(section);
+        latestTexts = await getVisibleItemTexts(section);
         return (
-            texts.length > 0 &&
-            texts.every((t) => t.length > 0 && !t.includes('Loading'))
+            latestTexts.length > 0 &&
+            latestTexts.every((t) => t.length > 0 && !t.includes('Loading'))
         );
-    }, timeoutMs);
+    }, timeoutMs).catch(async (err: unknown) => {
+        const title = await section.getTitle().catch(() => '<unknown section>');
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `${message}; section "${title}" visible items: ${latestTexts.join(', ') || '<none>'}`,
+        );
+    });
     // Reveal nested children (tree-mode capability groups) so all leaves are findable.
     await expandAllItems(section);
 }
@@ -539,10 +554,7 @@ export async function dismissAllNotifications(workbench: Workbench): Promise<voi
 /**
  * Returns true if any currently visible notification message includes `fragment`.
  */
-export async function hasNotification(
-    workbench: Workbench,
-    fragment: string,
-): Promise<boolean> {
+export async function hasNotification(workbench: Workbench, fragment: string): Promise<boolean> {
     try {
         const notes = await workbench.getNotifications();
         for (const n of notes) {

--- a/src/src/test/unit/commandHandlersCapabilityPluginMaintenance.test.ts
+++ b/src/src/test/unit/commandHandlersCapabilityPluginMaintenance.test.ts
@@ -476,6 +476,37 @@ suite('Command handler capability plugin maintenance helpers', () => {
         }
     });
 
+    test('Copilot plugin settings updates are serialized per settings path', () => {
+        const source = fs.readFileSync(
+            path.resolve(__dirname, '../../../src/commands/commandHandlers.ts'),
+            'utf-8',
+        );
+
+        assert.match(
+            source,
+            /const copilotPluginSettingsUpdateQueues = new Map<string, Promise<void>>\(\);/,
+        );
+        assert.match(source, /async function enqueueCopilotPluginSettingsUpdate\(/);
+        assert.match(source, /const next = previous\.then\(update, update\);/);
+        assert.match(
+            source,
+            /await enqueueCopilotPluginSettingsUpdate\(settingsPath, async \(\) => \{/,
+        );
+    });
+
+    test('Copilot plugin settings updates recover from blank or malformed local JSON', () => {
+        const source = fs.readFileSync(
+            path.resolve(__dirname, '../../../src/commands/commandHandlers.ts'),
+            'utf-8',
+        );
+
+        assert.match(source, /let rewriteExistingFromScratch = false;/);
+        assert.match(source, /if \(existing\.trim\(\)\.length === 0\) \{/);
+        assert.match(source, /rewriteExistingFromScratch = true;/);
+        assert.match(source, /const recoveredContent =/);
+        assert.match(source, /: '\{\}\\n';/);
+    });
+
     test('buildMaintainedCapabilityPluginManifestJson creates a valid plugin scaffold when absent', () => {
         const { buildMaintainedCapabilityPluginManifestJson } = loadCommandHandlers();
         const result = buildMaintainedCapabilityPluginManifestJson({

--- a/src/src/test/unit/commandHandlersConfigUpdateConsent.test.ts
+++ b/src/src/test/unit/commandHandlersConfigUpdateConsent.test.ts
@@ -22,7 +22,7 @@ suite('Command handler config update consent', () => {
         const refreshUpdateBlock = sourceSlice(
             source,
             'const shouldPersistConfig = autoAcceptRefreshUpdates',
-            'state.config = result.config;',
+            'state.builtInCapability = await loadBuiltInCapabilityRuntimeState(context);',
         );
 
         assert.match(
@@ -49,17 +49,21 @@ suite('Command handler config update consent', () => {
         const source = readCommandHandlersSource();
         const refreshOptionsBlock = sourceSlice(
             source,
-            'const refreshOptions = extractRefreshCommandOptions(arg);',
+            'const ws = getWorkspace({ showError: false });',
             'const pendingCapabilityPluginMetadataDirtyVersion',
         );
 
+        assert.match(
+            refreshOptionsBlock,
+            /state\.isLoading = false;\s+state\.onDidChange\.fire\(\);\s+return;/m,
+        );
         assert.match(refreshOptionsBlock, /context\.extensionMode === vscode\.ExtensionMode\.Test/);
         assert.match(refreshOptionsBlock, /refreshOptions\.nonInteractive === true/);
 
         const refreshUpdateBlock = sourceSlice(
             source,
             'const shouldPersistConfig = autoAcceptRefreshUpdates',
-            'if (shouldPersistConfig && capabilityRepairPreview) {'
+            'if (shouldPersistConfig && capabilityRepairPreview) {',
         );
         assert.match(refreshUpdateBlock, /autoAcceptRefreshUpdates\s+\? true/);
         assert.match(refreshUpdateBlock, /suppressRefreshUpdatePrompts\s+\? false/);
@@ -67,7 +71,7 @@ suite('Command handler config update consent', () => {
         const builtInRepairBlock = sourceSlice(
             source,
             'const shouldUpdateBuiltInState = autoAcceptRefreshUpdates',
-            'if (shouldUpdateBuiltInState) {'
+            'if (shouldUpdateBuiltInState) {',
         );
         assert.match(builtInRepairBlock, /autoAcceptRefreshUpdates\s+\? true/);
         assert.match(builtInRepairBlock, /suppressRefreshUpdatePrompts\s+\? false/);
@@ -81,7 +85,10 @@ suite('Command handler config update consent', () => {
             'const gitRepos = resolveGitBackedRepoSources',
         );
 
-        assert.match(refreshUpdateBlock, /if \(pendingRepairCount > 0\) \{\s+shouldAdvanceCapabilityIdentitySnapshot = false;/m);
+        assert.match(
+            refreshUpdateBlock,
+            /if \(pendingRepairCount > 0\) \{\s+shouldAdvanceCapabilityIdentitySnapshot = false;/m,
+        );
         assert.match(
             source,
             /if \(shouldAdvanceCapabilityIdentitySnapshot\) \{\s+saveCapabilityIdentitySnapshot\(projectedConfig, ws\.uri\.fsPath\);/m,
@@ -104,10 +111,7 @@ suite('Command handler config update consent', () => {
             builtInRepairBlock,
             /if \(shouldUpdateBuiltInState\) \{\s+state\.builtInCapability = await writeBuiltInCapabilityWorkspaceState\(/m,
         );
-        assert.match(
-            builtInRepairBlock,
-            /shouldAdvanceCapabilityIdentitySnapshot = false;/,
-        );
+        assert.match(builtInRepairBlock, /shouldAdvanceCapabilityIdentitySnapshot = false;/);
     });
 
     test('capability repair preview does not mutate loaded config before consent', () => {
@@ -123,5 +127,23 @@ suite('Command handler config update consent', () => {
             /const repairResult = applyCapabilityReferenceRepairs\(cloneConfig\(config\), resolutions\);/,
         );
         assert.doesNotMatch(previewHelper, /saveManagedState\(/);
+    });
+
+    test('refresh publishes loaded config before heavier refresh work', () => {
+        const source = readCommandHandlersSource();
+        const earlyPublishBlock = sourceSlice(
+            source,
+            'const discoveryResult = discoverAndPersistConfiguredRepoLayers(',
+            'let capabilityRepairPreview: CapabilityIdentityDriftRepairPreview | undefined;',
+        );
+
+        assert.match(earlyPublishBlock, /\{ enableDiscovery: true \},\s+\);/m);
+        assert.match(earlyPublishBlock, /state\.config = result\.config;/);
+        assert.match(earlyPublishBlock, /state\.configPath = result\.configPath;/);
+        assert.match(earlyPublishBlock, /state\.activeProfile = result\.config\.activeProfile;/);
+        assert.match(
+            earlyPublishBlock,
+            /state\.isLoading = false;\s+state\.onDidChange\.fire\(\);/m,
+        );
     });
 });

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -44,6 +44,7 @@ type ExtensionPackageJson = {
 };
 
 const EXTENSION_ROOT = path.resolve(__dirname, '../../..');
+const EXTENSION_ENTRYPOINT = path.join(EXTENSION_ROOT, 'src', 'extension.ts');
 
 suite('Extension Packaging Regression Guards', () => {
     test('multi-client VSIX install tasks pass a single comma-separated CLI list', () => {
@@ -121,7 +122,7 @@ suite('Extension Packaging Regression Guards', () => {
         assert.strictEqual(packageJson.main, './dist/extension.js');
     });
 
-    test('activation events only include the unified config location', () => {
+    test('activation events include config and MetaFlow view activation only', () => {
         const packageJsonPath = path.join(EXTENSION_ROOT, 'package.json');
         const packageJson = JSON.parse(
             fs.readFileSync(packageJsonPath, 'utf-8'),
@@ -129,10 +130,35 @@ suite('Extension Packaging Regression Guards', () => {
 
         const activationEvents = packageJson.activationEvents ?? [];
         assert.ok(activationEvents.includes('workspaceContains:**/.metaflow/config.jsonc'));
+        assert.ok(activationEvents.includes('onView:metaflow-config'));
+        assert.ok(activationEvents.includes('onView:metaflow-profiles'));
+        assert.ok(activationEvents.includes('onView:metaflow-layers'));
+        assert.ok(activationEvents.includes('onView:metaflow-files'));
         assert.strictEqual(
             activationEvents.includes('onStartupFinished'),
             false,
             'Expected activation to stay scoped to MetaFlow workspaces instead of all startup sessions',
+        );
+    });
+
+    test('activation refresh loads tree views without startup prompts', () => {
+        const extensionSource = fs.readFileSync(EXTENSION_ENTRYPOINT, 'utf-8');
+
+        assert.match(
+            extensionSource,
+            /const activationRefreshOptions = \{ skipRepoSync: true, nonInteractive: true \};/,
+        );
+        assert.match(
+            extensionSource,
+            /await vscode\.commands\.executeCommand\('metaflow\.refresh', activationRefreshOptions\);/,
+        );
+        assert.match(
+            extensionSource,
+            /vscode\.workspace\.onDidChangeWorkspaceFolders\(\(event\) => \{[\s\S]*event\.added\.length === 0[\s\S]*vscode\.commands\.executeCommand\('metaflow\.refresh', activationRefreshOptions\);[\s\S]*\}\)/,
+        );
+        assert.match(
+            extensionSource,
+            /if \(!isTestMode\) \{\s+await vscode\.commands\.executeCommand\('metaflow\.offerGitRemotePromotion'\);\s+await vscode\.commands\.executeCommand\('metaflow\.offerGitIgnoreStateConfiguration'\);\s+\}/,
         );
     });
 

--- a/src/test-workspace/.metaflow/config.jsonc
+++ b/src/test-workspace/.metaflow/config.jsonc
@@ -1,32 +1,32 @@
 {
-  "metadataRepos": [
-    {
-      "id": "primary",
-      "localPath": ".ai/ai-metadata",
-      "capabilities": [
-        {
-          "path": "company/core",
-          "enabled": false
-        },
-        {
-          "path": "standards/sdlc",
-          "enabled": true
-        }
-      ]
-    }
-  ],
-  "profiles": {
-    "default": {
-      "enable": [
-        "**/*"
-      ]
-    },
-    "review": {
-      "enable": [
-        "**/*"
-      ]
-    }
-  },
-  "activeProfile": "default",
-  "compatibilityVersion": 2
+	"metadataRepos": [
+		{
+			"id": "primary",
+			"localPath": ".ai/ai-metadata",
+			"capabilities": [
+				{
+					"path": "company/core",
+					"enabled": false
+				},
+				{
+					"path": "standards/sdlc",
+					"enabled": true
+				}
+			]
+		}
+	],
+	"profiles": {
+		"default": {
+			"enable": [
+				"**/*"
+			]
+		},
+		"review": {
+			"enable": [
+				"**/*"
+			]
+		}
+	},
+	"activeProfile": "default",
+	"compatibilityVersion": 2
 }


### PR DESCRIPTION
Summary
- Seeds the ignored GUI test golden config from the tracked workspace config before batched GUI runs.
- Restores the live config from the seeded golden before each batch so CI runs start with a clean fixture.

Validation
- node --check src/scripts/run-gui-batched.mjs
- Verified config.golden.jsonc can be seeded from test-workspace/.metaflow/config.jsonc