### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/preview-0-3-0-release.md
+++ b/.changeset/preview-0-3-0-release.md
@@ -1,7 +1,0 @@
----
-"metaflow-ai": minor
-"@metaflow/engine": minor
-"@metaflow/cli": minor
----
-
-Prepare the 0.3.0 prerelease lane for preview extension publishing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/cli": {
       "name": "@metaflow/cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@metaflow/engine": "file:../engine",
@@ -8958,7 +8958,7 @@
     },
     "packages/engine": {
       "name": "@metaflow/engine",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
@@ -9004,7 +9004,7 @@
     },
     "src": {
       "name": "metaflow-ai",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@metaflow/engine": "file:../packages/engine",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @metaflow/cli
 
+## 0.3.0
+
+### Minor Changes
+
+- 8bbae64: Prepare the 0.3.0 prerelease lane for preview extension publishing.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaflow/cli",
   "description": "CLI for layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "private": true,
   "bin": {

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @metaflow/engine
 
+## 0.3.0
+
+### Minor Changes
+
+- 8bbae64: Prepare the 0.3.0 prerelease lane for preview extension publishing.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaflow/engine",
   "description": "Engine for layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "private": true,
   "main": "out/src/index.js",

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+### Minor Changes
+
+- 8bbae64: Prepare the 0.3.0 prerelease lane for preview extension publishing.
+
 ## Unreleased
 
 ### Added

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "metaflow-ai",
   "displayName": "MetaFlow: AI Metadata Overlay",
   "description": "Layered AI metadata overlays for Copilot instructions, prompts, skills, and agents.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "dynfxdigital",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version Packages automation prepared this branch from 766f09a but could not open the PR because GitHub Actions lacks pull-request creation permission. Opening it manually so the prerelease path can continue.