### PR TITLE
fix(release): use absolute VSIX publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,9 @@ jobs:
             find artifacts -maxdepth 3 -type f
             exit 1
           fi
-          echo "vsix_path=$VSIX_PATH" >> "$GITHUB_OUTPUT"
-          echo "Downloaded VSIX: $VSIX_PATH"
+          ABS_VSIX_PATH="$GITHUB_WORKSPACE/$VSIX_PATH"
+          echo "vsix_path=$ABS_VSIX_PATH" >> "$GITHUB_OUTPUT"
+          echo "Downloaded VSIX: $ABS_VSIX_PATH"
 
       - name: Detect publish targets
         id: targets


### PR DESCRIPTION
The first release workflow fix proved the downloaded VSIX can be found, but the publish step still failed because `npm exec --workspace src` resolves relative paths from the `src` workspace context.

This change converts the resolved downloaded VSIX path into an absolute path under `$GITHUB_WORKSPACE` before it is passed to:
- VS Code Marketplace publish
- Open VSX publish
- GitHub Release upload

Why this is needed:
- the rerun reached `Publish to VS Code Marketplace`
- the workflow resolved `artifacts/metaflow-ai-0.3.0.vsix`
- `vsce publish` still failed with `ENOENT` because that relative path was evaluated from the workspace command context

Expected follow-up after merge:
- rerun `Release Extension`
- choose `main`
- choose `prerelease`