### PR TITLE
Merge develop into main

### DIFF
--- a/packages/engine/src/engine/overlayEngine.ts
+++ b/packages/engine/src/engine/overlayEngine.ts
@@ -374,6 +374,10 @@ function isKnownArtifactPath(relativePath: string): boolean {
     return KNOWN_ARTIFACT_ROOTS.has(topDir);
 }
 
+function isKnownArtifactRootDirectory(directoryName: string): boolean {
+    return KNOWN_ARTIFACT_ROOTS.has(directoryName);
+}
+
 /**
  * Discover layer directories in a repository by finding directories
  * that directly contain known artifact roots.
@@ -438,6 +442,9 @@ export function discoverLayersInRepo(repoRoot: string, excludePatterns: string[]
         for (const entry of entries) {
             const fullPath = path.join(currentDir, entry.name);
             if (getEntryKind(entry, fullPath) !== 'directory') {
+                continue;
+            }
+            if (isKnownArtifactRootDirectory(entry.name)) {
                 continue;
             }
             if (entry.name.startsWith('.') && entry.name !== '.github') {

--- a/packages/engine/test/engine.test.ts
+++ b/packages/engine/test/engine.test.ts
@@ -450,6 +450,31 @@ describe('Engine package: overlay pipeline', () => {
         assert.deepStrictEqual(discovered, ['capabilities/empty-capability']);
     });
 
+    it('does not discover artifact roots as standalone layer directories', () => {
+        const repoRoot = path.join(tmpDir, '.ai', 'discover-artifact-root-repo');
+        fs.mkdirSync(path.join(repoRoot, 'instructions', 'nested-capability'), {
+            recursive: true,
+        });
+        fs.mkdirSync(path.join(repoRoot, 'prompts'), { recursive: true });
+        fs.mkdirSync(path.join(repoRoot, 'agents'), { recursive: true });
+        fs.mkdirSync(path.join(repoRoot, 'skills', 'review-skill'), { recursive: true });
+        fs.mkdirSync(path.join(repoRoot, 'capabilities', 'real-capability'), {
+            recursive: true,
+        });
+        fs.writeFileSync(path.join(repoRoot, 'CAPABILITY.md'), '# Root Capability');
+        fs.writeFileSync(
+            path.join(repoRoot, 'instructions', 'nested-capability', 'CAPABILITY.md'),
+            '# Not a discovered layer',
+        );
+        fs.writeFileSync(
+            path.join(repoRoot, 'capabilities', 'real-capability', 'CAPABILITY.md'),
+            '# Real Capability',
+        );
+
+        const discovered = discoverLayersInRepo(repoRoot);
+        assert.deepStrictEqual(discovered, ['.', 'capabilities/real-capability']);
+    });
+
     it('classifies deprecated chatmodes as Synchronized-only', () => {
         const repoDir = path.join(tmpDir, '.ai', 'ai-metadata');
         fs.mkdirSync(path.join(repoDir, 'core', '.github', 'chatmodes'), { recursive: true });

--- a/src/package.json
+++ b/src/package.json
@@ -273,6 +273,11 @@
         "icon": "$(search)"
       },
       {
+        "command": "metaflow.clearLayersFilter",
+        "title": "MetaFlow: Clear Capabilities Filter",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "metaflow.collapseAllFiles",
         "title": "Collapse",
         "icon": "$(collapse-all)"
@@ -450,7 +455,12 @@
         },
         {
           "command": "metaflow.openLayersFilter",
-          "when": "view == metaflow-layers",
+          "when": "view == metaflow-layers && !metaflow.layersNativeFilterActive",
+          "group": "navigation@3"
+        },
+        {
+          "command": "metaflow.clearLayersFilter",
+          "when": "view == metaflow-layers && metaflow.layersNativeFilterActive",
           "group": "navigation@3"
         },
         {

--- a/src/package.json
+++ b/src/package.json
@@ -273,11 +273,6 @@
         "icon": "$(search)"
       },
       {
-        "command": "metaflow.clearLayersFilter",
-        "title": "MetaFlow: Clear Capabilities Filter",
-        "icon": "$(clear-all)"
-      },
-      {
         "command": "metaflow.collapseAllFiles",
         "title": "Collapse",
         "icon": "$(collapse-all)"
@@ -455,12 +450,7 @@
         },
         {
           "command": "metaflow.openLayersFilter",
-          "when": "view == metaflow-layers && !metaflow.layersNativeFilterActive",
-          "group": "navigation@3"
-        },
-        {
-          "command": "metaflow.clearLayersFilter",
-          "when": "view == metaflow-layers && metaflow.layersNativeFilterActive",
+          "when": "view == metaflow-layers",
           "group": "navigation@3"
         },
         {
@@ -844,11 +834,6 @@
         "key": "ctrl+f",
         "mac": "cmd+f",
         "when": "sideBarFocus && focusedView == 'metaflow-layers'"
-      },
-      {
-        "command": "metaflow.clearLayersFilter",
-        "key": "escape",
-        "when": "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive && treeFindOpen"
       },
       {
         "command": "metaflow.openFilesFilter",

--- a/src/package.json
+++ b/src/package.json
@@ -258,6 +258,16 @@
         "icon": "$(list-tree)"
       },
       {
+        "command": "metaflow.showLayersTreeMode",
+        "title": "MetaFlow: Show Capabilities Tree View",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "metaflow.showLayersFlatMode",
+        "title": "MetaFlow: Show Capabilities Flat View",
+        "icon": "$(list-flat)"
+      },
+      {
         "command": "metaflow.collapseAllLayers",
         "title": "Collapse",
         "icon": "$(collapse-all)"
@@ -454,8 +464,13 @@
           "group": "navigation@3"
         },
         {
-          "command": "metaflow.toggleLayersViewMode",
-          "when": "view == metaflow-layers",
+          "command": "metaflow.showLayersFlatMode",
+          "when": "view == metaflow-layers && metaflow.layersViewMode == tree",
+          "group": "navigation@5"
+        },
+        {
+          "command": "metaflow.showLayersTreeMode",
+          "when": "view == metaflow-layers && metaflow.layersViewMode == flat",
           "group": "navigation@5"
         },
         {

--- a/src/package.json
+++ b/src/package.json
@@ -836,6 +836,11 @@
         "when": "sideBarFocus && focusedView == 'metaflow-layers'"
       },
       {
+        "command": "metaflow.closeLayersFilter",
+        "key": "escape",
+        "when": "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive"
+      },
+      {
         "command": "metaflow.openFilesFilter",
         "key": "ctrl+f",
         "mac": "cmd+f",

--- a/src/package.json
+++ b/src/package.json
@@ -846,6 +846,11 @@
         "when": "sideBarFocus && focusedView == 'metaflow-layers'"
       },
       {
+        "command": "metaflow.clearLayersFilter",
+        "key": "escape",
+        "when": "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive && treeFindOpen"
+      },
+      {
         "command": "metaflow.openFilesFilter",
         "key": "ctrl+f",
         "mac": "cmd+f",

--- a/src/package.json
+++ b/src/package.json
@@ -836,11 +836,6 @@
         "when": "sideBarFocus && focusedView == 'metaflow-layers'"
       },
       {
-        "command": "metaflow.closeLayersFilter",
-        "key": "escape",
-        "when": "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive"
-      },
-      {
         "command": "metaflow.openFilesFilter",
         "key": "ctrl+f",
         "mac": "cmd+f",

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -8116,6 +8116,11 @@ export function registerCommands(
 
             writeManagedViewsState(ws.uri.fsPath, { filesViewMode: nextMode });
             await vscode.commands.executeCommand('setContext', 'metaflow.filesViewMode', nextMode);
+            try {
+                await vscode.commands.executeCommand('metaflow.refreshManagedViewModeContext');
+            } catch {
+                // Tests and partial activation hosts may not have registered the tree refresh hook.
+            }
             logInfo(`Effective Files view mode set to: ${nextMode}`);
         }),
     );
@@ -8133,6 +8138,11 @@ export function registerCommands(
 
             writeManagedViewsState(ws.uri.fsPath, { layersViewMode: nextMode });
             await vscode.commands.executeCommand('setContext', 'metaflow.layersViewMode', nextMode);
+            try {
+                await vscode.commands.executeCommand('metaflow.refreshManagedViewModeContext');
+            } catch {
+                // Tests and partial activation hosts may not have registered the tree refresh hook.
+            }
             logInfo(`Layers view mode set to: ${nextMode}`);
         }),
     );

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -4541,7 +4541,9 @@ export async function maintainAllCapabilityPluginMetadataInRepo(
         changedCount: changedResults.length,
         unchangedCount: unchangedResults.length,
         failureCount: failures.length,
-        changedCapabilities: changedResults.map((result) => result.capabilityDirectoryPath),
+        changedCapabilities: changedResults.map((result) =>
+            toRepoRelativeLayerPath(repoRoot, result.capabilityDirectoryPath),
+        ),
         failures,
         marketplacePath: marketplaceResult.marketplacePath,
         marketplaceChanged: marketplaceResult.changed,

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -313,6 +313,16 @@ function getWorkspace(): vscode.WorkspaceFolder | undefined {
     );
 }
 
+function getManagedViewWorkspace(): vscode.WorkspaceFolder | undefined {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+        vscode.window.showErrorMessage('MetaFlow: No workspace folder open.');
+        return undefined;
+    }
+
+    return folders[0];
+}
+
 function readManagedSettingsState(context: vscode.ExtensionContext): ManagedSettingsState {
     const raw = context.workspaceState.get<unknown>(SETTINGS_INJECTION_STATE_KEY);
     if (!raw || typeof raw !== 'object') {
@@ -8106,7 +8116,7 @@ export function registerCommands(
     // ── metaflow.toggleFilesViewMode ───────────────────────────────
     context.subscriptions.push(
         vscode.commands.registerCommand('metaflow.toggleFilesViewMode', async () => {
-            const ws = getWorkspace();
+            const ws = getManagedViewWorkspace();
             if (!ws) {
                 return;
             }
@@ -8125,10 +8135,45 @@ export function registerCommands(
         }),
     );
 
+    async function setLayersViewMode(ws: vscode.WorkspaceFolder, nextMode: LayersViewMode): Promise<void> {
+        writeManagedViewsState(ws.uri.fsPath, { layersViewMode: nextMode });
+        await vscode.commands.executeCommand('setContext', 'metaflow.layersViewMode', nextMode);
+        try {
+            await vscode.commands.executeCommand('metaflow.refreshManagedViewModeContext');
+        } catch {
+            // Tests and partial activation hosts may not have registered the tree refresh hook.
+        }
+        logInfo(`Layers view mode set to: ${nextMode}`);
+    }
+
+    // ── metaflow.showLayersFlatMode ────────────────────────────────
+    context.subscriptions.push(
+        vscode.commands.registerCommand('metaflow.showLayersFlatMode', async () => {
+            const ws = getManagedViewWorkspace();
+            if (!ws) {
+                return;
+            }
+
+            await setLayersViewMode(ws, 'flat');
+        }),
+    );
+
+    // ── metaflow.showLayersTreeMode ────────────────────────────────
+    context.subscriptions.push(
+        vscode.commands.registerCommand('metaflow.showLayersTreeMode', async () => {
+            const ws = getManagedViewWorkspace();
+            if (!ws) {
+                return;
+            }
+
+            await setLayersViewMode(ws, 'tree');
+        }),
+    );
+
     // ── metaflow.toggleLayersViewMode ──────────────────────────────
     context.subscriptions.push(
         vscode.commands.registerCommand('metaflow.toggleLayersViewMode', async () => {
-            const ws = getWorkspace();
+            const ws = getManagedViewWorkspace();
             if (!ws) {
                 return;
             }
@@ -8136,14 +8181,7 @@ export function registerCommands(
             const currentMode = readManagedViewsState(ws.uri.fsPath).layersViewMode;
             const nextMode: LayersViewMode = currentMode === 'flat' ? 'tree' : 'flat';
 
-            writeManagedViewsState(ws.uri.fsPath, { layersViewMode: nextMode });
-            await vscode.commands.executeCommand('setContext', 'metaflow.layersViewMode', nextMode);
-            try {
-                await vscode.commands.executeCommand('metaflow.refreshManagedViewModeContext');
-            } catch {
-                // Tests and partial activation hosts may not have registered the tree refresh hook.
-            }
-            logInfo(`Layers view mode set to: ${nextMode}`);
+            await setLayersViewMode(ws, nextMode);
         }),
     );
 

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -4440,6 +4440,24 @@ function toRepoRelativeLayerPath(repoRoot: string, capabilityDirectoryPath: stri
     return path.relative(repoRoot, absolutePath).replace(/\\/g, '/');
 }
 
+function hasCapabilityManifestAtPath(repoRoot: string, layerPath: string): boolean {
+    const manifestPath = path.join(repoRoot, layerPath, 'CAPABILITY.md');
+    try {
+        return fs.statSync(manifestPath).isFile();
+    } catch {
+        return false;
+    }
+}
+
+function discoverCapabilityDirectoryPathsInRepo(
+    repoRoot: string,
+    excludePatterns: string[] = [],
+): string[] {
+    return discoverLayersInRepo(repoRoot, excludePatterns).filter((layerPath) =>
+        hasCapabilityManifestAtPath(repoRoot, layerPath),
+    );
+}
+
 export function collectCapabilityPluginMaintenanceWarningMessages(options: {
     repoRoot: string;
     failures: CapabilityPluginMaintenanceFailure[];
@@ -4480,7 +4498,7 @@ export async function maintainAllCapabilityPluginMetadataInRepo(
             ? options.capabilityDirectoryPaths.map((capabilityDirectoryPath) =>
                   toRepoRelativeLayerPath(repoRoot, capabilityDirectoryPath),
               )
-            : discoverLayersInRepo(repoRoot, options.excludePatterns)
+            : discoverCapabilityDirectoryPathsInRepo(repoRoot, options.excludePatterns)
     ).sort((left, right) => left.localeCompare(right));
 
     const changedResults: Array<
@@ -8009,9 +8027,10 @@ export function registerCommands(
                 }
 
                 const repoRoot = resolvePathFromWorkspace(ws.uri.fsPath, repo.localPath);
-                const layerPaths = discoverLayersInRepo(repoRoot, repo.discover?.exclude).sort(
-                    (left, right) => left.localeCompare(right),
-                );
+                const layerPaths = discoverCapabilityDirectoryPathsInRepo(
+                    repoRoot,
+                    repo.discover?.exclude,
+                ).sort((left, right) => left.localeCompare(right));
                 if (layerPaths.length === 0) {
                     vscode.window.showInformationMessage(
                         `MetaFlow: No capability directories with CAPABILITY.md were found in ${repoRoot}.`,

--- a/src/src/commands/commandHandlers.ts
+++ b/src/src/commands/commandHandlers.ts
@@ -8156,7 +8156,10 @@ export function registerCommands(
         }),
     );
 
-    async function setLayersViewMode(ws: vscode.WorkspaceFolder, nextMode: LayersViewMode): Promise<void> {
+    async function setLayersViewMode(
+        ws: vscode.WorkspaceFolder,
+        nextMode: LayersViewMode,
+    ): Promise<void> {
         writeManagedViewsState(ws.uri.fsPath, { layersViewMode: nextMode });
         await vscode.commands.executeCommand('setContext', 'metaflow.layersViewMode', nextMode);
         try {

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -55,6 +55,10 @@ function isArtifactTypeNode(item: vscode.TreeItem): boolean {
     return contextValue === 'artifactTypeFolder' || contextValue.startsWith('layerArtifactType:');
 }
 
+function isConcreteCapabilityNode(item: vscode.TreeItem): boolean {
+    return getContextValue(item) === 'layer';
+}
+
 function isCapabilitySearchBoundary(
     item: vscode.TreeItem,
     children: readonly vscode.TreeItem[],
@@ -147,6 +151,12 @@ async function revealSearchBranches<T extends vscode.TreeItem>(
             continue;
         }
 
+        if (isConcreteCapabilityNode(child)) {
+            await treeView.reveal(child, { expand: 1, select: true, focus: true });
+            await vscode.commands.executeCommand('list.collapse');
+            continue;
+        }
+
         await treeView.reveal(child, { expand: 1, select: false, focus: false });
 
         const children = provider.getChildren(child);
@@ -194,11 +204,10 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
         // Fall back to the current sidebar focus when the generated focus command is unavailable.
     }
 
-    await vscode.commands.executeCommand('list.find');
-
-    void prepareTreeViewFilter(treeView, provider).catch((error: unknown) => {
+    await prepareTreeViewFilter(treeView, provider).catch((error: unknown) => {
         logWarn(`MetaFlow: Tree search preload failed: ${String(error)}`);
     });
+    await vscode.commands.executeCommand('list.find');
 }
 
 // ── Activation ─────────────────────────────────────────────────────

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -31,7 +31,12 @@ import {
     resolveCapabilityDetailTarget,
 } from './commands/capabilityDetails';
 import { isBuiltInCapabilityActive } from './builtInCapability';
-import { extractLayerPath, extractRepoId, readManagedViewsState } from './commands/commandHelpers';
+import {
+    extractLayerPath,
+    extractRepoId,
+    readManagedViewsState,
+    writeManagedViewsState,
+} from './commands/commandHelpers';
 import { CapabilityDetailsPanelManager } from './views/capabilityDetailsPanel';
 import { createRepoUpdateScheduler } from './repoUpdateScheduler';
 import { createRepoUpdateSchedulerLifecycleController } from './extensionSchedulerLifecycle';
@@ -44,10 +49,6 @@ type LayersViewMode = 'flat' | 'tree';
 
 type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
-};
-
-type NativeFindTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
-    setNativeFindActive(value: boolean): void;
 };
 
 function getContextValue(item: vscode.TreeItem): string {
@@ -218,48 +219,27 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
-async function openNativeFindTreeFilter<T extends vscode.TreeItem>(
-    viewId: string,
-    provider: NativeFindTreeProvider<T>,
+async function openLayersTreeFilter<T extends vscode.TreeItem>(
+    treeView: vscode.TreeView<T>,
+    provider: LayersTreeViewProvider & SearchPreparedTreeProvider<T>,
 ): Promise<void> {
-    await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
-
-    try {
-        await vscode.commands.executeCommand(`${viewId}.focus`);
-    } catch {
-        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (workspaceRoot) {
+        const currentMode = readManagedViewsState(workspaceRoot).layersViewMode;
+        if (currentMode !== 'flat') {
+            writeManagedViewsState(workspaceRoot, { layersViewMode: 'flat' });
+            await vscode.commands.executeCommand('setContext', 'metaflow.layersViewMode', 'flat');
+            provider.refresh();
+        }
     }
 
-    provider.setNativeFindActive(true);
-    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', true);
-    await vscode.commands.executeCommand('list.find');
-}
-
-async function closeNativeFindTreeFilter<T extends vscode.TreeItem>(
-    viewId: string,
-    provider: NativeFindTreeProvider<T>,
-): Promise<void> {
-    try {
-        await vscode.commands.executeCommand('list.closeFind');
-    } catch {
-        // The find widget may already be closed when focus has returned to the tree.
-    }
-
-    provider.setNativeFindActive(false);
-    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
-
-    try {
-        await vscode.commands.executeCommand(`${viewId}.focus`);
-    } catch {
-        // Fall back to the current sidebar focus when the generated focus command is unavailable.
-    }
+    await openTreeViewFilter('metaflow-layers', treeView, provider);
 }
 
 // ── Activation ─────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
     logInfo('MetaFlow extension activating...');
-    void vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
 
     // Read log level from settings
     const logLevel = vscode.workspace
@@ -319,6 +299,13 @@ export function activate(context: vscode.ExtensionContext): void {
         filesTreeViewProvider.refresh();
         layersTreeViewProvider.refresh();
     };
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'metaflow.refreshManagedViewModeContext',
+            syncManagedViewModeContext,
+        ),
+    );
 
     syncManagedViewModeContext();
     vscode.commands.executeCommand('setContext', 'metaflow.hasGitBackedRepo', false);
@@ -392,10 +379,7 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
-        }),
-        vscode.commands.registerCommand('metaflow.closeLayersFilter', async () => {
-            await closeNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
+            await openLayersTreeFilter(layersTreeView, layersTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -219,6 +219,37 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
+function waitForTreeViewRefresh(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+let layersFindModeForcedToFilter = false;
+
+async function forceLayersFindModeToFilter(): Promise<void> {
+    const defaultFindMode = vscode.workspace
+        .getConfiguration('workbench.list')
+        .get<string>('defaultFindMode', 'highlight');
+
+    if (defaultFindMode === 'filter' || layersFindModeForcedToFilter) {
+        return;
+    }
+
+    await vscode.commands.executeCommand('list.toggleFindMode');
+    layersFindModeForcedToFilter = true;
+}
+
+async function focusFirstTreeItem<T extends vscode.TreeItem>(
+    treeView: vscode.TreeView<T>,
+    provider: SearchPreparedTreeProvider<T>,
+): Promise<void> {
+    const firstItem = provider.getChildren()[0];
+    if (!firstItem) {
+        return;
+    }
+
+    await treeView.reveal(firstItem, { focus: true, select: false, expand: false });
+}
+
 async function openLayersTreeFilter<T extends vscode.TreeItem>(
     treeView: vscode.TreeView<T>,
     provider: LayersTreeViewProvider & SearchPreparedTreeProvider<T>,
@@ -233,7 +264,31 @@ async function openLayersTreeFilter<T extends vscode.TreeItem>(
         }
     }
 
-    await openTreeViewFilter('metaflow-layers', treeView, provider);
+    await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
+
+    try {
+        await vscode.commands.executeCommand('metaflow-layers.focus');
+    } catch {
+        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    }
+
+    await waitForTreeViewRefresh();
+
+    try {
+        await vscode.commands.executeCommand('workbench.actions.treeView.metaflow-layers.collapseAll');
+    } catch {
+        // Some VS Code hosts may not expose generated collapse-all commands.
+    }
+
+    await waitForTreeViewRefresh();
+    await focusFirstTreeItem(treeView, provider).catch((error: unknown) => {
+        logWarn(`MetaFlow: Tree search focus failed: ${String(error)}`);
+    });
+    await waitForTreeViewRefresh();
+    await vscode.commands.executeCommand('list.focusFirst');
+    await waitForTreeViewRefresh();
+    await forceLayersFindModeToFilter();
+    await vscode.commands.executeCommand('list.find');
 }
 
 // ── Activation ─────────────────────────────────────────────────────

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -46,8 +46,9 @@ type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
 };
 
-type NativeFindTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
-    setNativeFindActive(value: boolean): void;
+type ProviderFilteredTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
+    getSearchQuery(): string | undefined;
+    setSearchQuery(value: string | undefined): void;
 };
 
 function getContextValue(item: vscode.TreeItem): string {
@@ -214,9 +215,10 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
-async function openNativeFindTreeFilter<T extends vscode.TreeItem>(
+async function openProviderTreeFilter<T extends vscode.TreeItem>(
     viewId: string,
-    provider: NativeFindTreeProvider<T>,
+    provider: ProviderFilteredTreeProvider<T>,
+    title: string,
 ): Promise<void> {
     await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
 
@@ -226,36 +228,34 @@ async function openNativeFindTreeFilter<T extends vscode.TreeItem>(
         // Fall back to the current sidebar focus when the generated focus command is unavailable.
     }
 
-    provider.setNativeFindActive(true);
-    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', true);
-    await vscode.commands.executeCommand('list.find');
-}
-
-async function clearNativeFindTreeFilter<T extends vscode.TreeItem>(
-    viewId: string,
-    provider: NativeFindTreeProvider<T>,
-): Promise<void> {
-    try {
-        await vscode.commands.executeCommand('list.closeFind');
-    } catch {
-        // Some hosts may not have a focused list find widget when clearing from the title action.
-    }
-
-    provider.setNativeFindActive(false);
-    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
-
-    try {
-        await vscode.commands.executeCommand(`${viewId}.focus`);
-    } catch {
-        // Fall back to the current sidebar focus when the generated focus command is unavailable.
-    }
+    const input = vscode.window.createInputBox();
+    const disposables: vscode.Disposable[] = [];
+    input.title = title;
+    input.placeholder = 'Type to filter';
+    input.value = provider.getSearchQuery() ?? '';
+    disposables.push(
+        input.onDidChangeValue((value) => {
+            provider.setSearchQuery(value);
+        }),
+        input.onDidAccept(() => {
+            input.hide();
+        }),
+        input.onDidHide(() => {
+            provider.setSearchQuery(undefined);
+            for (const disposable of disposables) {
+                disposable.dispose();
+            }
+            input.dispose();
+        }),
+    );
+    provider.setSearchQuery(input.value);
+    input.show();
 }
 
 // ── Activation ─────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
     logInfo('MetaFlow extension activating...');
-    void vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
 
     // Read log level from settings
     const logLevel = vscode.workspace
@@ -388,10 +388,11 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
-        }),
-        vscode.commands.registerCommand('metaflow.clearLayersFilter', async () => {
-            await clearNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
+            await openProviderTreeFilter(
+                'metaflow-layers',
+                layersTreeViewProvider,
+                'Filter Capabilities',
+            );
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -46,11 +46,6 @@ type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
 };
 
-type ProviderFilteredTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
-    getSearchQuery(): string | undefined;
-    setSearchQuery(value: string | undefined): void;
-};
-
 function getContextValue(item: vscode.TreeItem): string {
     return typeof item.contextValue === 'string' ? item.contextValue : '';
 }
@@ -157,8 +152,6 @@ async function revealSearchBranches<T extends vscode.TreeItem>(
         }
 
         if (isConcreteCapabilityNode(child)) {
-            await treeView.reveal(child, { expand: 1, select: true, focus: true });
-            await vscode.commands.executeCommand('list.collapse');
             continue;
         }
 
@@ -190,9 +183,15 @@ async function collapseBranch<T extends vscode.TreeItem>(
 }
 
 async function prepareTreeViewFilter<T extends vscode.TreeItem>(
+    viewId: string,
     treeView: vscode.TreeView<T>,
     provider: SearchPreparedTreeProvider<T>,
 ): Promise<void> {
+    try {
+        await vscode.commands.executeCommand(`workbench.actions.treeView.${viewId}.collapseAll`);
+    } catch {
+        // Some VS Code hosts may not expose generated collapse-all commands.
+    }
     await revealSearchBranches(treeView, provider);
 }
 
@@ -209,47 +208,10 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
         // Fall back to the current sidebar focus when the generated focus command is unavailable.
     }
 
-    await prepareTreeViewFilter(treeView, provider).catch((error: unknown) => {
+    await prepareTreeViewFilter(viewId, treeView, provider).catch((error: unknown) => {
         logWarn(`MetaFlow: Tree search preload failed: ${String(error)}`);
     });
     await vscode.commands.executeCommand('list.find');
-}
-
-async function openProviderTreeFilter<T extends vscode.TreeItem>(
-    viewId: string,
-    provider: ProviderFilteredTreeProvider<T>,
-    title: string,
-): Promise<void> {
-    await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
-
-    try {
-        await vscode.commands.executeCommand(`${viewId}.focus`);
-    } catch {
-        // Fall back to the current sidebar focus when the generated focus command is unavailable.
-    }
-
-    const input = vscode.window.createInputBox();
-    const disposables: vscode.Disposable[] = [];
-    input.title = title;
-    input.placeholder = 'Type to filter';
-    input.value = provider.getSearchQuery() ?? '';
-    disposables.push(
-        input.onDidChangeValue((value) => {
-            provider.setSearchQuery(value);
-        }),
-        input.onDidAccept(() => {
-            input.hide();
-        }),
-        input.onDidHide(() => {
-            provider.setSearchQuery(undefined);
-            for (const disposable of disposables) {
-                disposable.dispose();
-            }
-            input.dispose();
-        }),
-    );
-    provider.setSearchQuery(input.value);
-    input.show();
 }
 
 // ── Activation ─────────────────────────────────────────────────────
@@ -388,11 +350,7 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openProviderTreeFilter(
-                'metaflow-layers',
-                layersTreeViewProvider,
-                'Filter Capabilities',
-            );
+            await openTreeViewFilter('metaflow-layers', layersTreeView, layersTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -46,9 +46,8 @@ type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
 };
 
-type ProviderFilteredTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
-    getSearchQuery(): string | undefined;
-    setSearchQuery(value: string | undefined): void;
+type NativeFindTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
+    setNativeFindActive(value: boolean): void;
 };
 
 function getContextValue(item: vscode.TreeItem): string {
@@ -215,10 +214,9 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
-async function openProviderTreeFilter<T extends vscode.TreeItem>(
+async function openNativeFindTreeFilter<T extends vscode.TreeItem>(
     viewId: string,
-    provider: ProviderFilteredTreeProvider<T>,
-    title: string,
+    provider: NativeFindTreeProvider<T>,
 ): Promise<void> {
     await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
 
@@ -228,34 +226,30 @@ async function openProviderTreeFilter<T extends vscode.TreeItem>(
         // Fall back to the current sidebar focus when the generated focus command is unavailable.
     }
 
-    const input = vscode.window.createInputBox();
-    const disposables: vscode.Disposable[] = [];
-    input.title = title;
-    input.placeholder = 'Type to filter';
-    input.value = provider.getSearchQuery() ?? '';
-    disposables.push(
-        input.onDidChangeValue((value) => {
-            provider.setSearchQuery(value);
-        }),
-        input.onDidAccept(() => {
-            input.hide();
-        }),
-        input.onDidHide(() => {
-            provider.setSearchQuery(undefined);
-            for (const disposable of disposables) {
-                disposable.dispose();
-            }
-            input.dispose();
-        }),
-    );
-    provider.setSearchQuery(input.value);
-    input.show();
+    provider.setNativeFindActive(true);
+    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', true);
+    await vscode.commands.executeCommand('list.find');
+}
+
+async function clearNativeFindTreeFilter<T extends vscode.TreeItem>(
+    viewId: string,
+    provider: NativeFindTreeProvider<T>,
+): Promise<void> {
+    provider.setNativeFindActive(false);
+    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
+
+    try {
+        await vscode.commands.executeCommand(`${viewId}.focus`);
+    } catch {
+        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    }
 }
 
 // ── Activation ─────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
     logInfo('MetaFlow extension activating...');
+    void vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
 
     // Read log level from settings
     const logLevel = vscode.workspace
@@ -388,11 +382,10 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openProviderTreeFilter(
-                'metaflow-layers',
-                layersTreeViewProvider,
-                'Filter Capabilities',
-            );
+            await openNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
+        }),
+        vscode.commands.registerCommand('metaflow.clearLayersFilter', async () => {
+            await clearNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -235,6 +235,12 @@ async function clearNativeFindTreeFilter<T extends vscode.TreeItem>(
     viewId: string,
     provider: NativeFindTreeProvider<T>,
 ): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('list.closeFind');
+    } catch {
+        // Some hosts may not have a focused list find widget when clearing from the title action.
+    }
+
     provider.setNativeFindActive(false);
     await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
 

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -46,6 +46,11 @@ type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
 };
 
+type ProviderFilteredTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
+    getSearchQuery(): string | undefined;
+    setSearchQuery(value: string | undefined): void;
+};
+
 function getContextValue(item: vscode.TreeItem): string {
     return typeof item.contextValue === 'string' ? item.contextValue : '';
 }
@@ -210,6 +215,43 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
+async function openProviderTreeFilter<T extends vscode.TreeItem>(
+    viewId: string,
+    provider: ProviderFilteredTreeProvider<T>,
+    title: string,
+): Promise<void> {
+    await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
+
+    try {
+        await vscode.commands.executeCommand(`${viewId}.focus`);
+    } catch {
+        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    }
+
+    const input = vscode.window.createInputBox();
+    const disposables: vscode.Disposable[] = [];
+    input.title = title;
+    input.placeholder = 'Type to filter';
+    input.value = provider.getSearchQuery() ?? '';
+    disposables.push(
+        input.onDidChangeValue((value) => {
+            provider.setSearchQuery(value);
+        }),
+        input.onDidAccept(() => {
+            input.hide();
+        }),
+        input.onDidHide(() => {
+            provider.setSearchQuery(undefined);
+            for (const disposable of disposables) {
+                disposable.dispose();
+            }
+            input.dispose();
+        }),
+    );
+    provider.setSearchQuery(input.value);
+    input.show();
+}
+
 // ── Activation ─────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -346,7 +388,11 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openTreeViewFilter('metaflow-layers', layersTreeView, layersTreeViewProvider);
+            await openProviderTreeFilter(
+                'metaflow-layers',
+                layersTreeViewProvider,
+                'Filter Capabilities',
+            );
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -46,6 +46,10 @@ type SearchPreparedTreeProvider<T extends vscode.TreeItem> = {
     getChildren(element?: T): T[];
 };
 
+type NativeFindTreeProvider<T extends vscode.TreeItem> = SearchPreparedTreeProvider<T> & {
+    setNativeFindActive(value: boolean): void;
+};
+
 function getContextValue(item: vscode.TreeItem): string {
     return typeof item.contextValue === 'string' ? item.contextValue : '';
 }
@@ -214,10 +218,48 @@ async function openTreeViewFilter<T extends vscode.TreeItem>(
     await vscode.commands.executeCommand('list.find');
 }
 
+async function openNativeFindTreeFilter<T extends vscode.TreeItem>(
+    viewId: string,
+    provider: NativeFindTreeProvider<T>,
+): Promise<void> {
+    await vscode.commands.executeCommand('workbench.view.extension.metaflow-container');
+
+    try {
+        await vscode.commands.executeCommand(`${viewId}.focus`);
+    } catch {
+        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    }
+
+    provider.setNativeFindActive(true);
+    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', true);
+    await vscode.commands.executeCommand('list.find');
+}
+
+async function closeNativeFindTreeFilter<T extends vscode.TreeItem>(
+    viewId: string,
+    provider: NativeFindTreeProvider<T>,
+): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('list.closeFind');
+    } catch {
+        // The find widget may already be closed when focus has returned to the tree.
+    }
+
+    provider.setNativeFindActive(false);
+    await vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
+
+    try {
+        await vscode.commands.executeCommand(`${viewId}.focus`);
+    } catch {
+        // Fall back to the current sidebar focus when the generated focus command is unavailable.
+    }
+}
+
 // ── Activation ─────────────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext): void {
     logInfo('MetaFlow extension activating...');
+    void vscode.commands.executeCommand('setContext', 'metaflow.layersNativeFilterActive', false);
 
     // Read log level from settings
     const logLevel = vscode.workspace
@@ -350,7 +392,10 @@ export function activate(context: vscode.ExtensionContext): void {
             await revealAll(filesTreeView, filesTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openLayersFilter', async () => {
-            await openTreeViewFilter('metaflow-layers', layersTreeView, layersTreeViewProvider);
+            await openNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
+        }),
+        vscode.commands.registerCommand('metaflow.closeLayersFilter', async () => {
+            await closeNativeFindTreeFilter('metaflow-layers', layersTreeViewProvider);
         }),
         vscode.commands.registerCommand('metaflow.openFilesFilter', async () => {
             await openTreeViewFilter('metaflow-files', filesTreeView, filesTreeViewProvider);

--- a/src/src/extension.ts
+++ b/src/src/extension.ts
@@ -223,21 +223,6 @@ function waitForTreeViewRefresh(): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, 150));
 }
 
-let layersFindModeForcedToFilter = false;
-
-async function forceLayersFindModeToFilter(): Promise<void> {
-    const defaultFindMode = vscode.workspace
-        .getConfiguration('workbench.list')
-        .get<string>('defaultFindMode', 'highlight');
-
-    if (defaultFindMode === 'filter' || layersFindModeForcedToFilter) {
-        return;
-    }
-
-    await vscode.commands.executeCommand('list.toggleFindMode');
-    layersFindModeForcedToFilter = true;
-}
-
 async function focusFirstTreeItem<T extends vscode.TreeItem>(
     treeView: vscode.TreeView<T>,
     provider: SearchPreparedTreeProvider<T>,
@@ -287,7 +272,6 @@ async function openLayersTreeFilter<T extends vscode.TreeItem>(
     await waitForTreeViewRefresh();
     await vscode.commands.executeCommand('list.focusFirst');
     await waitForTreeViewRefresh();
-    await forceLayersFindModeToFilter();
     await vscode.commands.executeCommand('list.find');
 }
 

--- a/src/src/test/integration/extension.test.ts
+++ b/src/src/test/integration/extension.test.ts
@@ -66,6 +66,8 @@ const EXPECTED_COMMANDS = [
     'metaflow.removeRepoSource',
     'metaflow.rescanRepository',
     'metaflow.selectAllLayers',
+    'metaflow.showLayersFlatMode',
+    'metaflow.showLayersTreeMode',
     'metaflow.status',
     'metaflow.switchProfile',
     'metaflow.toggleFilesViewMode',

--- a/src/src/test/unit/commandHandlersCapabilityPluginMaintenance.test.ts
+++ b/src/src/test/unit/commandHandlersCapabilityPluginMaintenance.test.ts
@@ -869,4 +869,61 @@ suite('Command handler capability plugin maintenance helpers', () => {
             fs.rmSync(repoRoot, { recursive: true, force: true });
         }
     });
+
+    test('maintainAllCapabilityPluginMetadataInRepo ignores grouping folders and repo-root metadata without CAPABILITY.md', async () => {
+        const { maintainAllCapabilityPluginMetadataInRepo } = loadCommandHandlers();
+        const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'metaflow-plugin-grouping-'));
+        try {
+            fs.mkdirSync(path.join(repoRoot, '.github', 'instructions'), { recursive: true });
+            fs.writeFileSync(
+                path.join(repoRoot, '.github', 'instructions', 'root.instructions.md'),
+                'root instructions\n',
+                'utf-8',
+            );
+
+            const groupingDir = path.join(repoRoot, 'capabilities', 'group');
+            const firstCapability = path.join(groupingDir, 'first');
+            const secondCapability = path.join(groupingDir, 'second');
+            fs.mkdirSync(firstCapability, { recursive: true });
+            fs.mkdirSync(secondCapability, { recursive: true });
+
+            for (const [capabilityRoot, name] of [
+                [firstCapability, 'First Capability'],
+                [secondCapability, 'Second Capability'],
+            ] as const) {
+                fs.writeFileSync(
+                    path.join(capabilityRoot, 'CAPABILITY.md'),
+                    [
+                        '---',
+                        `name: ${name}`,
+                        'description: Test capability',
+                        'agentPlugin: true',
+                        '---',
+                    ].join('\n'),
+                    'utf-8',
+                );
+            }
+
+            const result = await maintainAllCapabilityPluginMetadataInRepo(repoRoot, {
+                repoId: 'example-repo',
+            });
+
+            assert.strictEqual(result.scannedCount, 2);
+            assert.strictEqual(result.failureCount, 0);
+            assert.deepStrictEqual(result.changedCapabilities, [
+                'capabilities/group/first',
+                'capabilities/group/second',
+            ]);
+
+            const marketplace = JSON.parse(fs.readFileSync(result.marketplacePath, 'utf-8')) as {
+                plugins?: Array<{ source?: string }>;
+            };
+            assert.deepStrictEqual(
+                marketplace.plugins?.map((plugin) => plugin.source),
+                ['./capabilities/group/first', './capabilities/group/second'],
+            );
+        } finally {
+            fs.rmSync(repoRoot, { recursive: true, force: true });
+        }
+    });
 });

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -330,12 +330,20 @@ suite('Extension Packaging Regression Guards', () => {
         const layersFilterCommand = commands.find(
             (entry) => entry.command === 'metaflow.openLayersFilter',
         );
+        const layersClearFilterCommand = commands.find(
+            (entry) => entry.command === 'metaflow.clearLayersFilter',
+        );
         const filesFilterCommand = commands.find(
             (entry) => entry.command === 'metaflow.openFilesFilter',
         );
 
         assert.ok(layersFilterCommand, 'Expected metaflow.openLayersFilter command contribution');
         assert.strictEqual(layersFilterCommand?.icon, '$(search)');
+        assert.ok(
+            layersClearFilterCommand,
+            'Expected metaflow.clearLayersFilter command contribution',
+        );
+        assert.strictEqual(layersClearFilterCommand?.icon, '$(clear-all)');
         assert.ok(filesFilterCommand, 'Expected metaflow.openFilesFilter command contribution');
         assert.strictEqual(filesFilterCommand?.icon, '$(search)');
 
@@ -344,9 +352,17 @@ suite('Extension Packaging Regression Guards', () => {
             titleMenuEntries.some(
                 (entry) =>
                     entry.command === 'metaflow.openLayersFilter' &&
-                    entry.when === 'view == metaflow-layers',
+                    entry.when === 'view == metaflow-layers && !metaflow.layersNativeFilterActive',
             ),
             'Expected filter action in the Capabilities view title menu',
+        );
+        assert.ok(
+            titleMenuEntries.some(
+                (entry) =>
+                    entry.command === 'metaflow.clearLayersFilter' &&
+                    entry.when === 'view == metaflow-layers && metaflow.layersNativeFilterActive',
+            ),
+            'Expected clear filter action in the Capabilities view title menu',
         );
         assert.ok(
             titleMenuEntries.some(

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -493,7 +493,8 @@ suite('Extension Packaging Regression Guards', () => {
             titleMenuEntries
                 .filter((entry) =>
                     [
-                        'metaflow.toggleLayersViewMode',
+                        'metaflow.showLayersFlatMode',
+                        'metaflow.showLayersTreeMode',
                         'metaflow.collapseAllLayers',
                         'metaflow.expandAllLayers',
                     ].includes(entry.command),
@@ -510,7 +511,11 @@ suite('Extension Packaging Regression Guards', () => {
             filesEntries.get('metaflow.expandAllFiles'),
         );
         assert.strictEqual(
-            layersEntries.get('metaflow.toggleLayersViewMode'),
+            layersEntries.get('metaflow.showLayersFlatMode'),
+            filesEntries.get('metaflow.toggleFilesViewMode'),
+        );
+        assert.strictEqual(
+            layersEntries.get('metaflow.showLayersTreeMode'),
             filesEntries.get('metaflow.toggleFilesViewMode'),
         );
     });

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -371,16 +371,6 @@ suite('Extension Packaging Regression Guards', () => {
         assert.ok(
             keybindings.some(
                 (entry) =>
-                    entry.command === 'metaflow.closeLayersFilter' &&
-                    entry.key === 'escape' &&
-                    entry.when ===
-                        "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive",
-            ),
-            'Expected Escape binding to restore the Capabilities tree after native find',
-        );
-        assert.ok(
-            keybindings.some(
-                (entry) =>
                     entry.command === 'metaflow.openFilesFilter' &&
                     entry.key === 'ctrl+f' &&
                     entry.mac === 'cmd+f' &&

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -371,6 +371,16 @@ suite('Extension Packaging Regression Guards', () => {
         assert.ok(
             keybindings.some(
                 (entry) =>
+                    entry.command === 'metaflow.closeLayersFilter' &&
+                    entry.key === 'escape' &&
+                    entry.when ===
+                        "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive",
+            ),
+            'Expected Escape binding to restore the Capabilities tree after native find',
+        );
+        assert.ok(
+            keybindings.some(
+                (entry) =>
                     entry.command === 'metaflow.openFilesFilter' &&
                     entry.key === 'ctrl+f' &&
                     entry.mac === 'cmd+f' &&

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -330,20 +330,12 @@ suite('Extension Packaging Regression Guards', () => {
         const layersFilterCommand = commands.find(
             (entry) => entry.command === 'metaflow.openLayersFilter',
         );
-        const layersClearFilterCommand = commands.find(
-            (entry) => entry.command === 'metaflow.clearLayersFilter',
-        );
         const filesFilterCommand = commands.find(
             (entry) => entry.command === 'metaflow.openFilesFilter',
         );
 
         assert.ok(layersFilterCommand, 'Expected metaflow.openLayersFilter command contribution');
         assert.strictEqual(layersFilterCommand?.icon, '$(search)');
-        assert.ok(
-            layersClearFilterCommand,
-            'Expected metaflow.clearLayersFilter command contribution',
-        );
-        assert.strictEqual(layersClearFilterCommand?.icon, '$(clear-all)');
         assert.ok(filesFilterCommand, 'Expected metaflow.openFilesFilter command contribution');
         assert.strictEqual(filesFilterCommand?.icon, '$(search)');
 
@@ -352,17 +344,9 @@ suite('Extension Packaging Regression Guards', () => {
             titleMenuEntries.some(
                 (entry) =>
                     entry.command === 'metaflow.openLayersFilter' &&
-                    entry.when === 'view == metaflow-layers && !metaflow.layersNativeFilterActive',
+                    entry.when === 'view == metaflow-layers',
             ),
             'Expected filter action in the Capabilities view title menu',
-        );
-        assert.ok(
-            titleMenuEntries.some(
-                (entry) =>
-                    entry.command === 'metaflow.clearLayersFilter' &&
-                    entry.when === 'view == metaflow-layers && metaflow.layersNativeFilterActive',
-            ),
-            'Expected clear filter action in the Capabilities view title menu',
         );
         assert.ok(
             titleMenuEntries.some(
@@ -383,16 +367,6 @@ suite('Extension Packaging Regression Guards', () => {
                     entry.when === "sideBarFocus && focusedView == 'metaflow-layers'",
             ),
             'Expected focused Ctrl+F binding for the Capabilities filter',
-        );
-        assert.ok(
-            keybindings.some(
-                (entry) =>
-                    entry.command === 'metaflow.clearLayersFilter' &&
-                    entry.key === 'escape' &&
-                    entry.when ===
-                        "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive && treeFindOpen",
-            ),
-            'Expected Escape binding to dismiss the active Capabilities filter',
         );
         assert.ok(
             keybindings.some(

--- a/src/src/test/unit/extensionPackagingRegression.test.ts
+++ b/src/src/test/unit/extensionPackagingRegression.test.ts
@@ -387,6 +387,16 @@ suite('Extension Packaging Regression Guards', () => {
         assert.ok(
             keybindings.some(
                 (entry) =>
+                    entry.command === 'metaflow.clearLayersFilter' &&
+                    entry.key === 'escape' &&
+                    entry.when ===
+                        "focusedView == 'metaflow-layers' && metaflow.layersNativeFilterActive && treeFindOpen",
+            ),
+            'Expected Escape binding to dismiss the active Capabilities filter',
+        );
+        assert.ok(
+            keybindings.some(
+                (entry) =>
                     entry.command === 'metaflow.openFilesFilter' &&
                     entry.key === 'ctrl+f' &&
                     entry.mac === 'cmd+f' &&

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -2327,39 +2327,27 @@ suite('LayersTreeView – artifact-type children', () => {
 
         provider.setSearchQuery('developer');
 
-        const roots = provider.getChildren();
-        assert.strictEqual(roots.length, 1, 'expected a single visible repo root');
-        assert.strictEqual(roots[0].collapsibleState, 2, 'repo root should auto-expand');
-
-        const repoChildren = provider.getChildren(roots[0]);
         assert.deepStrictEqual(
-            repoChildren.map((item) => String(item.label)),
-            ['capabilities'],
-        );
-        assert.strictEqual(repoChildren[0].collapsibleState, 2, 'capabilities should auto-expand');
-
-        const capabilityFolders = provider.getChildren(repoChildren[0]);
-        assert.deepStrictEqual(
-            capabilityFolders.map((item) => String(item.label)),
-            ['devtools'],
-            'non-matching capability folders should be hidden',
-        );
-        assert.strictEqual(capabilityFolders[0].collapsibleState, 2, 'ancestor should auto-expand');
-
-        const capabilityMatches = provider.getChildren(capabilityFolders[0]);
-        assert.deepStrictEqual(
-            capabilityMatches.map((item) => String(item.label)),
+            provider.getChildren().map((item) => String(item.label)),
             ['Developer Tooling'],
+            'only matching capability rows should remain visible',
         );
         assert.strictEqual(
-            capabilityMatches[0].collapsibleState,
-            1,
-            'matching capability should not be pre-expanded into artifact rows',
+            provider.getChildren()[0].collapsibleState,
+            0,
+            'matching capability should not be expandable into artifact rows while filtered',
         );
         assert.deepStrictEqual(
-            provider.getChildren(capabilityMatches[0]).map((item) => String(item.label)),
+            provider.getChildren(provider.getChildren()[0]).map((item) => String(item.label)),
             [],
             'capabilities search should not reveal artifact rows under matching capabilities',
+        );
+
+        provider.setSearchQuery('service');
+        assert.deepStrictEqual(
+            provider.getChildren().map((item) => String(item.label)),
+            ['Runtime Service'],
+            'previous matching capabilities should be removed as the query changes',
         );
 
         provider.setSearchQuery('instructions');

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -111,7 +111,6 @@ type LayersTreeViewModule = {
         };
         getParent(element: MockLayerTreeItem): MockLayerTreeItem | undefined;
         setSearchQuery(value: string | undefined): void;
-        setNativeFindActive(value: boolean): void;
     };
 };
 
@@ -2359,64 +2358,4 @@ suite('LayersTreeView – artifact-type children', () => {
         );
     });
 
-    test('LTV-SCH-02: native find mode exposes a flat capability search surface', () => {
-        const { LayersTreeViewProvider } = loadLayersTreeView();
-        const config = {
-            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
-            layerSources: [
-                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
-                { repoId: 'repo1', path: 'capabilities/runtime/service' },
-            ],
-        };
-        const capabilityByLayer = {
-            'repo1/capabilities/devtools/tooling': { name: 'Developer Tooling' },
-            'repo1/capabilities/runtime/service': { name: 'Runtime Service' },
-        };
-        const provider = new LayersTreeViewProvider(
-            makeState(
-                config,
-                [
-                    makeEffectiveFile(
-                        'instructions/tooling.md',
-                        'repo1',
-                        'capabilities/devtools/tooling',
-                    ),
-                    makeEffectiveFile(
-                        'skills/service/SKILL.md',
-                        'repo1',
-                        'capabilities/runtime/service',
-                    ),
-                ],
-                capabilityByLayer,
-            ),
-            () => 'tree',
-        );
-
-        provider.setNativeFindActive(true);
-
-        const visibleLabels = provider.getChildren().map((item) => String(item.label));
-        assert.deepStrictEqual(
-            visibleLabels,
-            ['Developer Tooling', 'Runtime Service'],
-            'native find should receive a flat capability list instead of a nested hierarchy',
-        );
-        assert.ok(
-            provider.getChildren().every(
-                (item) =>
-                    item.collapsibleState === mockVscode.TreeItemCollapsibleState.None,
-            ),
-            'native find candidates should not expand into artifact rows',
-        );
-        assert.ok(
-            !visibleLabels.includes('instructions') && !visibleLabels.includes('skills'),
-            'native find should not expose artifact directory rows in the Capabilities view',
-        );
-
-        provider.setNativeFindActive(false);
-        assert.deepStrictEqual(
-            provider.getChildren().map((item) => String(item.label)),
-            ['CoreMeta'],
-            'clearing native find should restore the normal tree root',
-        );
-    });
 });

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -1069,6 +1069,38 @@ suite('LayersTreeView – artifact-type children', () => {
         assert.strictEqual(provider.getParent(devtoolsNode), capabilitiesNode);
     });
 
+    test('LTV-S-06: tree search descends through mixed capability nodes to matching descendants', () => {
+        const { LayersTreeViewProvider } = loadLayersTreeView();
+        const config = {
+            metadataRepos: [{ id: 'repo1', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: 'capabilities' },
+                { repoId: 'repo1', path: 'capabilities/devtools' },
+            ],
+        };
+        const files = [
+            makeEffectiveFile('instructions/root.md', 'repo1', 'capabilities'),
+            makeEffectiveFile('prompts/devtools.md', 'repo1', 'capabilities/devtools'),
+        ];
+        const capabilityByLayer = {
+            'repo1/capabilities': { id: 'capabilities', name: 'Capabilities Root' },
+            'repo1/capabilities/devtools': { id: 'devtools', name: 'Developer Tools' },
+        };
+
+        const provider = new LayersTreeViewProvider(
+            makeState(config, files, capabilityByLayer),
+            () => 'tree',
+        );
+
+        provider.setSearchQuery('developer');
+
+        assert.deepStrictEqual(
+            provider.getChildren().map((item) => String(item.label)),
+            ['Developer Tools'],
+            'search should surface the descendant capability under a mixed parent node',
+        );
+    });
+
     test('LTV-AT-12: single-repo tree mode shows artifact-type children for layer nodes', () => {
         const { LayersTreeViewProvider } = loadLayersTreeView();
         const config = {

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -2219,7 +2219,7 @@ suite('LayersTreeView – artifact-type children', () => {
         );
     });
 
-    test('LTV-SEA-01b: tree branch nodes do not mix artifact browse rows with capability folders', () => {
+    test('LTV-SEA-01b: tree keeps root metadata separate from top-level capability folders', () => {
         const { LayersTreeViewProvider } = loadLayersTreeView();
         const config = {
             metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
@@ -2244,16 +2244,30 @@ suite('LayersTreeView – artifact-type children', () => {
         );
 
         const repoItem = provider.getChildren()[0];
-        const rootItem = provider.getChildren(repoItem)[0];
+        const repoChildren = provider.getChildren(repoItem);
+        assert.deepStrictEqual(
+            repoChildren.map((item) => String(item.label)),
+            ['root', 'capabilities'],
+            'root should be a repo-level metadata node, not the parent of every capability folder',
+        );
+
+        const rootItem = repoChildren.find((item) => String(item.label) === 'root');
+        assert.ok(rootItem, 'root layer should be reachable');
         const rootChildren = provider.getChildren(rootItem);
 
         assert.deepStrictEqual(
             rootChildren.map((item) => String(item.label)),
-            ['capabilities'],
-            'root should show capability folders, not raw artifact browse rows',
+            ['instructions', 'prompts', 'agents', 'skills'],
+            'root should show only repo-level artifact browse rows',
+        );
+        assert.ok(
+            rootChildren.every((item) => String(item.contextValue).startsWith('layerArtifactType:')),
+            'root children should be artifact browse rows',
         );
 
-        const capabilitiesChildren = provider.getChildren(rootChildren[0]);
+        const capabilitiesItem = repoChildren.find((item) => String(item.label) === 'capabilities');
+        assert.ok(capabilitiesItem, 'capabilities folder should be a root sibling');
+        const capabilitiesChildren = provider.getChildren(capabilitiesItem);
         const devtoolsItem = capabilitiesChildren.find((item) => String(item.label) === 'devtools');
         assert.ok(devtoolsItem, 'devtools branch should be reachable');
         const toolingItem = provider

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -2315,7 +2315,9 @@ suite('LayersTreeView – artifact-type children', () => {
             'root should show only repo-level artifact browse rows',
         );
         assert.ok(
-            rootChildren.every((item) => String(item.contextValue).startsWith('layerArtifactType:')),
+            rootChildren.every((item) =>
+                String(item.contextValue).startsWith('layerArtifactType:'),
+            ),
             'root children should be artifact browse rows',
         );
 
@@ -2411,5 +2413,4 @@ suite('LayersTreeView – artifact-type children', () => {
             'artifact-only matches should not keep non-matching capabilities visible',
         );
     });
-
 });

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -2292,29 +2292,81 @@ suite('LayersTreeView – artifact-type children', () => {
         assert.deepStrictEqual(provider.getStagedExpandPlan(), { stageOne: [], stageTwo: [] });
     });
 
-    test('LTV-SCH-01: tree search keeps only matching artifact branches and expands ancestors', () => {
+    test('LTV-SCH-01: tree search keeps matching capabilities without expanding artifact rows', () => {
         const { LayersTreeViewProvider } = loadLayersTreeView();
-        const config = makeMultiRepoConfig();
+        const config = {
+            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
+                { repoId: 'repo1', path: 'capabilities/runtime/service' },
+            ],
+        };
+        const capabilityByLayer = {
+            'repo1/capabilities/devtools/tooling': { name: 'Developer Tooling' },
+            'repo1/capabilities/runtime/service': { name: 'Runtime Service' },
+        };
         const provider = new LayersTreeViewProvider(
-            makeState(config, ALL_TYPES_FILES),
+            makeState(
+                config,
+                [
+                    makeEffectiveFile(
+                        'instructions/tooling.md',
+                        'repo1',
+                        'capabilities/devtools/tooling',
+                    ),
+                    makeEffectiveFile(
+                        'instructions/service.md',
+                        'repo1',
+                        'capabilities/runtime/service',
+                    ),
+                ],
+                capabilityByLayer,
+            ),
             () => 'tree',
         );
 
-        provider.setSearchQuery('prompts');
+        provider.setSearchQuery('developer');
 
         const roots = provider.getChildren();
         assert.strictEqual(roots.length, 1, 'expected a single visible repo root');
         assert.strictEqual(roots[0].collapsibleState, 2, 'repo root should auto-expand');
 
         const repoChildren = provider.getChildren(roots[0]);
-        assert.strictEqual(repoChildren.length, 1, 'expected a single visible layer');
-        assert.strictEqual(repoChildren[0].contextValue, 'layer');
-        assert.strictEqual(repoChildren[0].collapsibleState, 2, 'layer should auto-expand');
-
-        const layerChildren = provider.getChildren(repoChildren[0]);
         assert.deepStrictEqual(
-            layerChildren.map((item) => String(item.label)),
-            ['prompts'],
+            repoChildren.map((item) => String(item.label)),
+            ['capabilities'],
+        );
+        assert.strictEqual(repoChildren[0].collapsibleState, 2, 'capabilities should auto-expand');
+
+        const capabilityFolders = provider.getChildren(repoChildren[0]);
+        assert.deepStrictEqual(
+            capabilityFolders.map((item) => String(item.label)),
+            ['devtools'],
+            'non-matching capability folders should be hidden',
+        );
+        assert.strictEqual(capabilityFolders[0].collapsibleState, 2, 'ancestor should auto-expand');
+
+        const capabilityMatches = provider.getChildren(capabilityFolders[0]);
+        assert.deepStrictEqual(
+            capabilityMatches.map((item) => String(item.label)),
+            ['Developer Tooling'],
+        );
+        assert.strictEqual(
+            capabilityMatches[0].collapsibleState,
+            1,
+            'matching capability should not be pre-expanded into artifact rows',
+        );
+        assert.deepStrictEqual(
+            provider.getChildren(capabilityMatches[0]).map((item) => String(item.label)),
+            [],
+            'capabilities search should not reveal artifact rows under matching capabilities',
+        );
+
+        provider.setSearchQuery('instructions');
+        assert.deepStrictEqual(
+            provider.getChildren().map((item) => String(item.label)),
+            [],
+            'artifact-only matches should not keep non-matching capabilities visible',
         );
     });
 });

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -2397,15 +2397,8 @@ suite('LayersTreeView – artifact-type children', () => {
         const visibleLabels = provider.getChildren().map((item) => String(item.label));
         assert.deepStrictEqual(
             visibleLabels,
-            [
-                'CoreMeta',
-                'capabilities',
-                'devtools',
-                'Developer Tooling',
-                'runtime',
-                'Runtime Service',
-            ],
-            'native find should receive a flat list instead of a nested hierarchy',
+            ['Developer Tooling', 'Runtime Service'],
+            'native find should receive a flat capability list instead of a nested hierarchy',
         );
         assert.ok(
             provider.getChildren().every(

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -111,6 +111,7 @@ type LayersTreeViewModule = {
         };
         getParent(element: MockLayerTreeItem): MockLayerTreeItem | undefined;
         setSearchQuery(value: string | undefined): void;
+        setNativeFindActive(value: boolean): void;
     };
 };
 
@@ -2355,6 +2356,72 @@ suite('LayersTreeView – artifact-type children', () => {
             provider.getChildren().map((item) => String(item.label)),
             [],
             'artifact-only matches should not keep non-matching capabilities visible',
+        );
+    });
+
+    test('LTV-SCH-02: native find mode exposes label-only flat capability candidates', () => {
+        const { LayersTreeViewProvider } = loadLayersTreeView();
+        const config = {
+            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
+                { repoId: 'repo1', path: 'capabilities/runtime/service' },
+            ],
+        };
+        const capabilityByLayer = {
+            'repo1/capabilities/devtools/tooling': { name: 'Developer Tooling' },
+            'repo1/capabilities/runtime/service': { name: 'Runtime Service' },
+        };
+        const provider = new LayersTreeViewProvider(
+            makeState(
+                config,
+                [
+                    makeEffectiveFile(
+                        'instructions/tooling.md',
+                        'repo1',
+                        'capabilities/devtools/tooling',
+                    ),
+                    makeEffectiveFile(
+                        'skills/service/SKILL.md',
+                        'repo1',
+                        'capabilities/runtime/service',
+                    ),
+                ],
+                capabilityByLayer,
+            ),
+            () => 'tree',
+        );
+
+        provider.setNativeFindActive(true);
+
+        const candidates = provider.getChildren();
+        assert.deepStrictEqual(
+            candidates.map((item) => String(item.label)),
+            ['Developer Tooling', 'Runtime Service'],
+            'native find should receive only flat capability candidates',
+        );
+        assert.ok(
+            candidates.every(
+                (item) =>
+                    item.collapsibleState === mockVscode.TreeItemCollapsibleState.None,
+            ),
+            'native find candidates should not expand into artifact rows',
+        );
+        assert.ok(
+            candidates.every((item) => item.description === undefined && item.tooltip === undefined),
+            'native find candidates should not expose metadata descriptions as match text',
+        );
+        assert.deepStrictEqual(
+            provider.getChildren(candidates[0]).map((item) => String(item.label)),
+            [],
+            'native find candidates should not expose children',
+        );
+
+        provider.setNativeFindActive(false);
+        assert.deepStrictEqual(
+            provider.getChildren().map((item) => String(item.label)),
+            ['CoreMeta'],
+            'clearing native find mode should restore the normal tree',
         );
     });
 

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -1929,6 +1929,28 @@ suite('LayersTreeView – artifact-type children', () => {
         );
     });
 
+    test('LTV-NF-02b: flat mode hides grouping-only branch directories with descendant capabilities', () => {
+        const { LayersTreeViewProvider } = loadLayersTreeView();
+        const config = {
+            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: 'general/devtools' },
+                { repoId: 'repo1', path: 'general/devtools/dev-tools' },
+            ],
+        };
+        const capabilityByLayer = {
+            'repo1/general/devtools/dev-tools': { id: 'dev-tools', name: 'Dev Tools' },
+        };
+        const provider = new LayersTreeViewProvider(
+            makeState(config, [], capabilityByLayer),
+            () => 'flat',
+        );
+
+        const labels = provider.getChildren().map((item) => String(item.label));
+
+        assert.deepStrictEqual(labels, ['Dev Tools']);
+    });
+
     test('LTV-NF-03: tree mode – leaf node uses capability name as label', () => {
         const { LayersTreeViewProvider } = loadLayersTreeView();
         const config = {

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -111,7 +111,6 @@ type LayersTreeViewModule = {
         };
         getParent(element: MockLayerTreeItem): MockLayerTreeItem | undefined;
         setSearchQuery(value: string | undefined): void;
-        setNativeFindActive(value: boolean): void;
     };
 };
 
@@ -2356,72 +2355,6 @@ suite('LayersTreeView – artifact-type children', () => {
             provider.getChildren().map((item) => String(item.label)),
             [],
             'artifact-only matches should not keep non-matching capabilities visible',
-        );
-    });
-
-    test('LTV-SCH-02: native find mode exposes label-only flat capability candidates', () => {
-        const { LayersTreeViewProvider } = loadLayersTreeView();
-        const config = {
-            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
-            layerSources: [
-                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
-                { repoId: 'repo1', path: 'capabilities/runtime/service' },
-            ],
-        };
-        const capabilityByLayer = {
-            'repo1/capabilities/devtools/tooling': { name: 'Developer Tooling' },
-            'repo1/capabilities/runtime/service': { name: 'Runtime Service' },
-        };
-        const provider = new LayersTreeViewProvider(
-            makeState(
-                config,
-                [
-                    makeEffectiveFile(
-                        'instructions/tooling.md',
-                        'repo1',
-                        'capabilities/devtools/tooling',
-                    ),
-                    makeEffectiveFile(
-                        'skills/service/SKILL.md',
-                        'repo1',
-                        'capabilities/runtime/service',
-                    ),
-                ],
-                capabilityByLayer,
-            ),
-            () => 'tree',
-        );
-
-        provider.setNativeFindActive(true);
-
-        const candidates = provider.getChildren();
-        assert.deepStrictEqual(
-            candidates.map((item) => String(item.label)),
-            ['Developer Tooling', 'Runtime Service'],
-            'native find should receive only flat capability candidates',
-        );
-        assert.ok(
-            candidates.every(
-                (item) =>
-                    item.collapsibleState === mockVscode.TreeItemCollapsibleState.None,
-            ),
-            'native find candidates should not expand into artifact rows',
-        );
-        assert.ok(
-            candidates.every((item) => item.description === undefined && item.tooltip === undefined),
-            'native find candidates should not expose metadata descriptions as match text',
-        );
-        assert.deepStrictEqual(
-            provider.getChildren(candidates[0]).map((item) => String(item.label)),
-            [],
-            'native find candidates should not expose children',
-        );
-
-        provider.setNativeFindActive(false);
-        assert.deepStrictEqual(
-            provider.getChildren().map((item) => String(item.label)),
-            ['CoreMeta'],
-            'clearing native find mode should restore the normal tree',
         );
     });
 

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -1005,7 +1005,7 @@ suite('LayersTreeView – artifact-type children', () => {
         assert.deepStrictEqual(labels, ['instructions', 'skills']);
     });
 
-    test('LTV-AT-11: mixed layer/folder node shows descendant layers and artifact browse rows', () => {
+    test('LTV-AT-11: mixed layer/folder node prefers descendant layers over artifact browse rows', () => {
         const { LayersTreeViewProvider } = loadLayersTreeView();
         const config = {
             metadataRepos: [{ id: 'repo1', localPath: '/repo1' }],
@@ -1029,10 +1029,17 @@ suite('LayersTreeView – artifact-type children', () => {
         const capabilitiesChildren = provider.getChildren(capabilitiesNode);
         const childLabels = capabilitiesChildren.map((c) => String(c.label));
 
-        assert.ok(childLabels.includes('devtools'), 'should include descendant layer folder');
-        assert.ok(
-            childLabels.includes('instructions'),
-            'should include artifact type from capabilities layer',
+        assert.deepStrictEqual(
+            childLabels,
+            ['devtools'],
+            'branch layer should show descendant capability folders only',
+        );
+
+        const [devtoolsNode] = capabilitiesChildren;
+        assert.deepStrictEqual(
+            provider.getChildren(devtoolsNode).map((c) => String(c.label)),
+            ['prompts'],
+            'leaf layer should still show artifact browse rows',
         );
     });
 
@@ -2209,6 +2216,54 @@ suite('LayersTreeView – artifact-type children', () => {
         assert.ok(
             !plan.stageOne.concat(plan.stageTwo).some((item) => String(item.label) === 'skills'),
             'skill folders should never be auto-expanded by the staged plan',
+        );
+    });
+
+    test('LTV-SEA-01b: tree branch nodes do not mix artifact browse rows with capability folders', () => {
+        const { LayersTreeViewProvider } = loadLayersTreeView();
+        const config = {
+            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: '.' },
+                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
+            ],
+        };
+        const provider = new LayersTreeViewProvider(
+            makeState(config, [
+                makeEffectiveFile('instructions/a.md', 'repo1', '.'),
+                makeEffectiveFile('prompts/b.md', 'repo1', '.'),
+                makeEffectiveFile('agents/c.md', 'repo1', '.'),
+                makeEffectiveFile('skills/d.md', 'repo1', '.'),
+                makeEffectiveFile(
+                    'instructions/tooling.md',
+                    'repo1',
+                    'capabilities/devtools/tooling',
+                ),
+            ]),
+            () => 'tree',
+        );
+
+        const repoItem = provider.getChildren()[0];
+        const rootItem = provider.getChildren(repoItem)[0];
+        const rootChildren = provider.getChildren(rootItem);
+
+        assert.deepStrictEqual(
+            rootChildren.map((item) => String(item.label)),
+            ['capabilities'],
+            'root should show capability folders, not raw artifact browse rows',
+        );
+
+        const capabilitiesChildren = provider.getChildren(rootChildren[0]);
+        const devtoolsItem = capabilitiesChildren.find((item) => String(item.label) === 'devtools');
+        assert.ok(devtoolsItem, 'devtools branch should be reachable');
+        const toolingItem = provider
+            .getChildren(devtoolsItem)
+            .find((item) => String(item.label) === 'tooling');
+        assert.ok(toolingItem, 'leaf capability should be reachable');
+        assert.deepStrictEqual(
+            provider.getChildren(toolingItem).map((item) => String(item.label)),
+            ['instructions'],
+            'leaf capability should still expose artifact browse rows',
         );
     });
 

--- a/src/src/test/unit/layersTreeView.test.ts
+++ b/src/src/test/unit/layersTreeView.test.ts
@@ -111,6 +111,7 @@ type LayersTreeViewModule = {
         };
         getParent(element: MockLayerTreeItem): MockLayerTreeItem | undefined;
         setSearchQuery(value: string | undefined): void;
+        setNativeFindActive(value: boolean): void;
     };
 };
 
@@ -2355,6 +2356,74 @@ suite('LayersTreeView – artifact-type children', () => {
             provider.getChildren().map((item) => String(item.label)),
             [],
             'artifact-only matches should not keep non-matching capabilities visible',
+        );
+    });
+
+    test('LTV-SCH-02: native find mode exposes a flat capability search surface', () => {
+        const { LayersTreeViewProvider } = loadLayersTreeView();
+        const config = {
+            metadataRepos: [{ id: 'repo1', name: 'CoreMeta', localPath: '/repo1' }],
+            layerSources: [
+                { repoId: 'repo1', path: 'capabilities/devtools/tooling' },
+                { repoId: 'repo1', path: 'capabilities/runtime/service' },
+            ],
+        };
+        const capabilityByLayer = {
+            'repo1/capabilities/devtools/tooling': { name: 'Developer Tooling' },
+            'repo1/capabilities/runtime/service': { name: 'Runtime Service' },
+        };
+        const provider = new LayersTreeViewProvider(
+            makeState(
+                config,
+                [
+                    makeEffectiveFile(
+                        'instructions/tooling.md',
+                        'repo1',
+                        'capabilities/devtools/tooling',
+                    ),
+                    makeEffectiveFile(
+                        'skills/service/SKILL.md',
+                        'repo1',
+                        'capabilities/runtime/service',
+                    ),
+                ],
+                capabilityByLayer,
+            ),
+            () => 'tree',
+        );
+
+        provider.setNativeFindActive(true);
+
+        const visibleLabels = provider.getChildren().map((item) => String(item.label));
+        assert.deepStrictEqual(
+            visibleLabels,
+            [
+                'CoreMeta',
+                'capabilities',
+                'devtools',
+                'Developer Tooling',
+                'runtime',
+                'Runtime Service',
+            ],
+            'native find should receive a flat list instead of a nested hierarchy',
+        );
+        assert.ok(
+            provider.getChildren().every(
+                (item) =>
+                    item.collapsibleState === mockVscode.TreeItemCollapsibleState.None,
+            ),
+            'native find candidates should not expand into artifact rows',
+        );
+        assert.ok(
+            !visibleLabels.includes('instructions') && !visibleLabels.includes('skills'),
+            'native find should not expose artifact directory rows in the Capabilities view',
+        );
+
+        provider.setNativeFindActive(false);
+        assert.deepStrictEqual(
+            provider.getChildren().map((item) => String(item.label)),
+            ['CoreMeta'],
+            'clearing native find should restore the normal tree root',
         );
     });
 });

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -838,6 +838,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     private readonly parsedMetadataByPath = new Map<string, ParsedMetadata | null>();
     private readonly directoryManifestByPath = new Map<string, DirectoryManifestMetadata | null>();
     private searchQuery: string | undefined;
+    private nativeFindActive = false;
     private searchVersion = 0;
 
     constructor(
@@ -870,6 +871,23 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
     getSearchQuery(): string | undefined {
         return this.searchQuery;
+    }
+
+    setNativeFindActive(value: boolean): void {
+        if (this.nativeFindActive === value) {
+            return;
+        }
+
+        this.nativeFindActive = value;
+        if (value) {
+            this.searchQuery = undefined;
+        }
+        this.searchVersion += 1;
+        this._onDidChangeTreeData.fire(undefined);
+    }
+
+    isNativeFindActive(): boolean {
+        return this.nativeFindActive;
     }
 
     getTreeItem(element: LayerTreeItem): vscode.TreeItem {
@@ -963,7 +981,20 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return !(element instanceof LayerItem && typeof element.layerIndex === 'number');
     }
 
-    private getFlatTreeSearchMatches(element?: LayerTreeItem): LayerTreeItem[] {
+    private prepareNativeFindCandidate<T extends LayerTreeItem>(element: T): T {
+        element.description = undefined;
+        element.tooltip = undefined;
+        element.accessibilityInformation = {
+            label: String(element.label ?? ''),
+            role: element.accessibilityInformation?.role,
+        };
+        return element;
+    }
+
+    private getFlatTreeSearchMatches(
+        element?: LayerTreeItem,
+        options: { nativeFind?: boolean } = {},
+    ): LayerTreeItem[] {
         const matches: LayerTreeItem[] = [];
         for (const child of this.getChildrenCore(element)) {
             if (child instanceof ArtifactTypeLayerItem) {
@@ -977,11 +1008,11 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 if (typeof child.id === 'string' && child.id.length > 0) {
                     child.id = `${child.id}|search:${this.searchVersion}`;
                 }
-                matches.push(child);
+                matches.push(options.nativeFind ? this.prepareNativeFindCandidate(child) : child);
             }
 
             if (canDescend) {
-                matches.push(...this.getFlatTreeSearchMatches(child));
+                matches.push(...this.getFlatTreeSearchMatches(child, options));
             }
         }
 
@@ -989,6 +1020,15 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
+        if (this.nativeFindActive && this.modeResolver() === 'tree') {
+            return element
+                ? []
+                : this.trackChildren(
+                      this.getFlatTreeSearchMatches(undefined, { nativeFind: true }),
+                      undefined,
+                  );
+        }
+
         if (this.searchQuery && this.modeResolver() === 'tree') {
             return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
         }
@@ -2215,7 +2255,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     getChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        return this.searchQuery ? this.getSearchFilteredChildren(element) : this.getChildrenCore(element);
+        return this.searchQuery || this.nativeFindActive
+            ? this.getSearchFilteredChildren(element)
+            : this.getChildrenCore(element);
     }
 
     getExpandAllStrategy(): ExpandAllStrategy {

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -989,7 +989,8 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
             }
 
             const canDescend = this.canSearchDescendInto(child);
-            if (this.matchesSearch(child)) {
+            const isCapability = child instanceof LayerItem && typeof child.layerIndex === 'number';
+            if (isCapability && this.matchesSearch(child)) {
                 child.collapsibleState = vscode.TreeItemCollapsibleState.None;
                 if (typeof child.id === 'string' && child.id.length > 0) {
                     child.id = `${child.id}|search:${this.searchVersion}`;

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -838,6 +838,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     private readonly parsedMetadataByPath = new Map<string, ParsedMetadata | null>();
     private readonly directoryManifestByPath = new Map<string, DirectoryManifestMetadata | null>();
     private searchQuery: string | undefined;
+    private nativeFindActive = false;
     private searchVersion = 0;
 
     constructor(
@@ -870,6 +871,23 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
     getSearchQuery(): string | undefined {
         return this.searchQuery;
+    }
+
+    setNativeFindActive(value: boolean): void {
+        if (this.nativeFindActive === value) {
+            return;
+        }
+
+        this.nativeFindActive = value;
+        if (value) {
+            this.searchQuery = undefined;
+        }
+        this.searchVersion += 1;
+        this._onDidChangeTreeData.fire(undefined);
+    }
+
+    isNativeFindActive(): boolean {
+        return this.nativeFindActive;
     }
 
     getTreeItem(element: LayerTreeItem): vscode.TreeItem {
@@ -988,6 +1006,10 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
+        if (this.nativeFindActive && this.modeResolver() === 'tree') {
+            return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
+        }
+
         if (this.searchQuery && this.modeResolver() === 'tree') {
             return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
         }
@@ -2214,7 +2236,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     getChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        return this.searchQuery
+        return this.searchQuery || this.nativeFindActive
             ? this.getSearchFilteredChildren(element)
             : this.getChildrenCore(element);
     }

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -1531,6 +1531,31 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return [];
     }
 
+    private shouldShowFlatEntry(entry: LayerEntry, entries: LayerEntry[]): boolean {
+        if (entry.capability) {
+            return true;
+        }
+
+        const entryRepoId = entry.repoId ?? 'primary';
+        const hasDescendantEntries = entries.some((candidate) => {
+            if (candidate === entry) {
+                return false;
+            }
+
+            if ((candidate.repoId ?? 'primary') !== entryRepoId) {
+                return false;
+            }
+
+            if (entry.normalizedPath === '') {
+                return candidate.normalizedPath !== '';
+            }
+
+            return candidate.normalizedPath.startsWith(`${entry.normalizedPath}/`);
+        });
+
+        return !hasDescendantEntries;
+    }
+
     private getLayerAvailability(
         layerIndex: number,
         repoId?: string,
@@ -2010,7 +2035,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 return [];
             }
 
-            return entries.map(
+            return entries.filter((entry) => this.shouldShowFlatEntry(entry, entries)).map(
                 (entry) =>
                     new LayerItem(entry.label, entry.enabled, entry.layerIndex, {
                         itemId: buildLayerTreeItemId(

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -354,6 +354,14 @@ interface LayerEntry {
     };
 }
 
+function buildLayerEntryRepoKey(entry: LayerEntry): string {
+    return entry.repoId ?? 'primary';
+}
+
+function buildLayerEntryPathKey(repoId: string, normalizedPath: string): string {
+    return `${repoId}:${normalizedPath}`;
+}
+
 interface LayerAvailability {
     repoEnabled: boolean;
     layerEnabled: boolean;
@@ -960,7 +968,11 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
             return true;
         }
 
-        return !(element instanceof LayerItem && typeof element.layerIndex === 'number');
+        if (!(element instanceof LayerItem) || typeof element.layerIndex !== 'number') {
+            return true;
+        }
+
+        return this.getChildrenCore(element).some((child) => !(child instanceof ArtifactTypeLayerItem));
     }
 
     private getFlatTreeSearchMatches(element?: LayerTreeItem): LayerTreeItem[] {
@@ -1531,29 +1543,34 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return [];
     }
 
-    private shouldShowFlatEntry(entry: LayerEntry, entries: LayerEntry[]): boolean {
+    private buildFlatModeDescendantKeySet(entries: LayerEntry[]): Set<string> {
+        const keys = new Set<string>();
+
+        for (const entry of entries) {
+            const repoKey = buildLayerEntryRepoKey(entry);
+            const segments = entry.normalizedPath.split('/').filter(Boolean);
+
+            if (segments.length === 0) {
+                continue;
+            }
+
+            keys.add(buildLayerEntryPathKey(repoKey, ''));
+            for (let index = 1; index < segments.length; index += 1) {
+                keys.add(buildLayerEntryPathKey(repoKey, segments.slice(0, index).join('/')));
+            }
+        }
+
+        return keys;
+    }
+
+    private shouldShowFlatEntry(entry: LayerEntry, descendantKeySet: Set<string>): boolean {
         if (entry.capability) {
             return true;
         }
 
-        const entryRepoId = entry.repoId ?? 'primary';
-        const hasDescendantEntries = entries.some((candidate) => {
-            if (candidate === entry) {
-                return false;
-            }
-
-            if ((candidate.repoId ?? 'primary') !== entryRepoId) {
-                return false;
-            }
-
-            if (entry.normalizedPath === '') {
-                return candidate.normalizedPath !== '';
-            }
-
-            return candidate.normalizedPath.startsWith(`${entry.normalizedPath}/`);
-        });
-
-        return !hasDescendantEntries;
+        return !descendantKeySet.has(
+            buildLayerEntryPathKey(buildLayerEntryRepoKey(entry), entry.normalizedPath),
+        );
     }
 
     private getLayerAvailability(
@@ -2035,7 +2052,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 return [];
             }
 
-            return entries.filter((entry) => this.shouldShowFlatEntry(entry, entries)).map(
+            const descendantKeySet = this.buildFlatModeDescendantKeySet(entries);
+
+            return entries.filter((entry) => this.shouldShowFlatEntry(entry, descendantKeySet)).map(
                 (entry) =>
                     new LayerItem(entry.label, entry.enabled, entry.layerIndex, {
                         itemId: buildLayerTreeItemId(

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -700,7 +700,9 @@ function buildArtifactTypeContextValue(artifactType: CapabilityArtifactType): st
     return `layerArtifactType:${artifactType}`;
 }
 
-function formatArtifactTypeCountLabel(counts: ArtifactSummaryCounts | undefined): string | undefined {
+function formatArtifactTypeCountLabel(
+    counts: ArtifactSummaryCounts | undefined,
+): string | undefined {
     if (!counts) {
         return undefined;
     }
@@ -972,7 +974,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
             return true;
         }
 
-        return this.getChildrenCore(element).some((child) => !(child instanceof ArtifactTypeLayerItem));
+        return this.getChildrenCore(element).some(
+            (child) => !(child instanceof ArtifactTypeLayerItem),
+        );
     }
 
     private getFlatTreeSearchMatches(element?: LayerTreeItem): LayerTreeItem[] {
@@ -1011,8 +1015,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         }
 
         return children.filter((child) => {
-            const descendantMatches =
-                this.canSearchDescendInto(child) ? this.getSearchFilteredChildren(child) : [];
+            const descendantMatches = this.canSearchDescendInto(child)
+                ? this.getSearchFilteredChildren(child)
+                : [];
             const include = this.matchesSearch(child) || descendantMatches.length > 0;
 
             if (include && descendantMatches.length > 0) {
@@ -1939,9 +1944,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         const layerRepoId = layerSource?.repoId ?? 'primary';
         const layerPath = layerSource?.path ?? singleLayerPath ?? '.';
         const normalizedLayerPath = normalizeRelativePath(layerPath);
-        const layerId = layerSource
-            ? `${layerRepoId}/${layerPath}`
-            : singleLayerPath!;
+        const layerId = layerSource ? `${layerRepoId}/${layerPath}` : singleLayerPath!;
         const normalizedLayerId = this.normalizeLayerId(layerId);
 
         const result = new Set<CapabilityArtifactType>();
@@ -2054,49 +2057,51 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
             const descendantKeySet = this.buildFlatModeDescendantKeySet(entries);
 
-            return entries.filter((entry) => this.shouldShowFlatEntry(entry, descendantKeySet)).map(
-                (entry) =>
-                    new LayerItem(entry.label, entry.enabled, entry.layerIndex, {
-                        itemId: buildLayerTreeItemId(
-                            'layer',
-                            'flat',
-                            entry.repoId,
-                            entry.normalizedPath || '.',
-                        ),
-                        repoId: entry.repoId,
-                        repoLabel: entry.repoLabel,
-                        showRepoLabelInDescription: true,
-                        repoDisabled: entry.repoDisabled,
-                        toggleable: entry.toggleable,
-                        hasChildren: false,
-                        path: entry.normalizedPath || '(root)',
-                        layerPath: entry.normalizedPath || '.',
-                        showPathInDescription: true,
-                        capabilityName: entry.capability?.name,
-                        capabilityId: entry.capability?.id,
-                        capabilityDescription: entry.capability?.description,
-                        capabilityLicense: entry.capability?.license,
-                        capabilityExperimental: entry.capability?.experimental,
-                        summary: this.summarizePath(
-                            entry.repoId ?? 'primary',
-                            entry.normalizedPath || '.',
-                        ),
-                        scopeSummary: summarizeLayerInstructionScope(
-                            this.state.treeSummaryCache,
-                            entry.repoId ?? 'primary',
-                            entry.normalizedPath || '.',
-                        ),
-                        governance: buildCapabilityGovernanceProjection(
-                            entry.repoId,
-                            entry.normalizedPath || '.',
-                            {
-                                governanceContract: this.state.governanceContract,
-                                governanceContractErrors: this.state.governanceContractErrors,
-                                governanceCompliance: this.state.governanceCompliance,
-                            },
-                        ),
-                    }),
-            );
+            return entries
+                .filter((entry) => this.shouldShowFlatEntry(entry, descendantKeySet))
+                .map(
+                    (entry) =>
+                        new LayerItem(entry.label, entry.enabled, entry.layerIndex, {
+                            itemId: buildLayerTreeItemId(
+                                'layer',
+                                'flat',
+                                entry.repoId,
+                                entry.normalizedPath || '.',
+                            ),
+                            repoId: entry.repoId,
+                            repoLabel: entry.repoLabel,
+                            showRepoLabelInDescription: true,
+                            repoDisabled: entry.repoDisabled,
+                            toggleable: entry.toggleable,
+                            hasChildren: false,
+                            path: entry.normalizedPath || '(root)',
+                            layerPath: entry.normalizedPath || '.',
+                            showPathInDescription: true,
+                            capabilityName: entry.capability?.name,
+                            capabilityId: entry.capability?.id,
+                            capabilityDescription: entry.capability?.description,
+                            capabilityLicense: entry.capability?.license,
+                            capabilityExperimental: entry.capability?.experimental,
+                            summary: this.summarizePath(
+                                entry.repoId ?? 'primary',
+                                entry.normalizedPath || '.',
+                            ),
+                            scopeSummary: summarizeLayerInstructionScope(
+                                this.state.treeSummaryCache,
+                                entry.repoId ?? 'primary',
+                                entry.normalizedPath || '.',
+                            ),
+                            governance: buildCapabilityGovernanceProjection(
+                                entry.repoId,
+                                entry.normalizedPath || '.',
+                                {
+                                    governanceContract: this.state.governanceContract,
+                                    governanceContractErrors: this.state.governanceContractErrors,
+                                    governanceCompliance: this.state.governanceCompliance,
+                                },
+                            ),
+                        }),
+                );
         }
 
         if (element instanceof LayerRepoItem) {
@@ -2259,7 +2264,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     getChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        return this.searchQuery ? this.getSearchFilteredChildren(element) : this.getChildrenCore(element);
+        return this.searchQuery
+            ? this.getSearchFilteredChildren(element)
+            : this.getChildrenCore(element);
     }
 
     getExpandAllStrategy(): ExpandAllStrategy {

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -963,14 +963,33 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return !(element instanceof LayerItem && typeof element.layerIndex === 'number');
     }
 
+    private getFlatTreeSearchMatches(element?: LayerTreeItem): LayerTreeItem[] {
+        const matches: LayerTreeItem[] = [];
+        for (const child of this.getChildrenCore(element)) {
+            if (child instanceof ArtifactTypeLayerItem) {
+                continue;
+            }
+
+            const canDescend = this.canSearchDescendInto(child);
+            if (this.matchesSearch(child)) {
+                child.collapsibleState = vscode.TreeItemCollapsibleState.None;
+                if (typeof child.id === 'string' && child.id.length > 0) {
+                    child.id = `${child.id}|search:${this.searchVersion}`;
+                }
+                matches.push(child);
+            }
+
+            if (canDescend) {
+                matches.push(...this.getFlatTreeSearchMatches(child));
+            }
+        }
+
+        return matches;
+    }
+
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        if (
-            this.searchQuery &&
-            this.modeResolver() === 'tree' &&
-            element instanceof LayerItem &&
-            typeof element.layerIndex === 'number'
-        ) {
-            return [];
+        if (this.searchQuery && this.modeResolver() === 'tree') {
+            return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
         }
 
         const children = this.getChildrenCore(element);

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -838,7 +838,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     private readonly parsedMetadataByPath = new Map<string, ParsedMetadata | null>();
     private readonly directoryManifestByPath = new Map<string, DirectoryManifestMetadata | null>();
     private searchQuery: string | undefined;
-    private nativeFindActive = false;
     private searchVersion = 0;
 
     constructor(
@@ -871,23 +870,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
     getSearchQuery(): string | undefined {
         return this.searchQuery;
-    }
-
-    setNativeFindActive(value: boolean): void {
-        if (this.nativeFindActive === value) {
-            return;
-        }
-
-        this.nativeFindActive = value;
-        if (value) {
-            this.searchQuery = undefined;
-        }
-        this.searchVersion += 1;
-        this._onDidChangeTreeData.fire(undefined);
-    }
-
-    isNativeFindActive(): boolean {
-        return this.nativeFindActive;
     }
 
     getTreeItem(element: LayerTreeItem): vscode.TreeItem {
@@ -1007,10 +989,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        if (this.nativeFindActive && this.modeResolver() === 'tree') {
-            return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
-        }
-
         if (this.searchQuery && this.modeResolver() === 'tree') {
             return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
         }
@@ -2237,9 +2215,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     getChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        return this.searchQuery || this.nativeFindActive
-            ? this.getSearchFilteredChildren(element)
-            : this.getChildrenCore(element);
+        return this.searchQuery ? this.getSearchFilteredChildren(element) : this.getChildrenCore(element);
     }
 
     getExpandAllStrategy(): ExpandAllStrategy {

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -59,6 +59,15 @@ const KNOWN_ARTIFACT_TYPES = new Set<CapabilityArtifactType>([
     'agents',
     'skills',
 ]);
+const RESERVED_LAYER_TERMINAL_SEGMENTS = new Set<string>([
+    ...KNOWN_ARTIFACT_TYPES,
+    'hooks',
+    'chatmodes',
+    '.github',
+    '.agents',
+    '.claude',
+    '.codex',
+]);
 
 interface ParsedMetadata {
     fields?: Record<string, string>;
@@ -173,6 +182,17 @@ function pathStartsWith(candidate: string, prefix: string): boolean {
         normalizedCandidate === normalizedPrefix ||
         normalizedCandidate.startsWith(`${normalizedPrefix}/`)
     );
+}
+
+function isReservedArtifactContainerLayerPath(layerPath: string): boolean {
+    const normalized = normalizeRelativePath(layerPath);
+    if (normalized === '.') {
+        return false;
+    }
+
+    const segments = normalized.split('/').filter(Boolean);
+    const terminalSegment = segments[segments.length - 1];
+    return RESERVED_LAYER_TERMINAL_SEGMENTS.has(terminalSegment);
 }
 
 function toDisplayTitleFromSlug(value: string): string {
@@ -1393,6 +1413,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 const layerId = `${ls.repoId}/${ls.path}`;
                 const capability = capabilityByLayer.get(this.normalizeLayerId(layerId));
                 const normalizedPath = this.normalizeLayerPath(ls.path);
+                if (isReservedArtifactContainerLayerPath(normalizedPath)) {
+                    return acc;
+                }
                 const summary = this.state.treeSummaryCache
                     ? this.summarizePath(ls.repoId, normalizedPath)
                     : undefined;
@@ -1435,6 +1458,9 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 const normalizedLayerId = this.normalizeLayerId(layer);
                 const capability = capabilityByLayer.get(normalizedLayerId);
                 const normalizedPath = this.normalizeLayerPath(layer);
+                if (isReservedArtifactContainerLayerPath(normalizedPath)) {
+                    return acc;
+                }
                 const summary = this.state.treeSummaryCache
                     ? this.summarizePath('primary', normalizedPath)
                     : undefined;
@@ -2018,8 +2044,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 ? entries.filter((entry) => entry.repoId === element.repoId)
                 : entries.filter((entry) => entry.repoId === undefined);
 
-            // A node can be both a concrete layer (has layerIndex) and a folder with child layers.
-            // In that case, expose both descendants and artifact-type browse rows.
+            // Branch nodes stay structural; leaf capability nodes expose artifact-type browse rows.
             const folderChildren = this.getTreeChildrenForPrefix(
                 repoEntries,
                 parentPath,
@@ -2040,7 +2065,10 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                     return this.trackChildren(artifactChildren, element);
                 }
 
-                return this.trackChildren([...folderChildren, ...artifactChildren], element);
+                return this.trackChildren(
+                    folderChildren.length > 0 ? folderChildren : artifactChildren,
+                    element,
+                );
             }
 
             return this.trackChildren(folderChildren, element);

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -838,7 +838,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     private readonly parsedMetadataByPath = new Map<string, ParsedMetadata | null>();
     private readonly directoryManifestByPath = new Map<string, DirectoryManifestMetadata | null>();
     private searchQuery: string | undefined;
-    private nativeFindActive = false;
     private searchVersion = 0;
 
     constructor(
@@ -871,23 +870,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
     getSearchQuery(): string | undefined {
         return this.searchQuery;
-    }
-
-    setNativeFindActive(value: boolean): void {
-        if (this.nativeFindActive === value) {
-            return;
-        }
-
-        this.nativeFindActive = value;
-        if (value) {
-            this.searchQuery = undefined;
-        }
-        this.searchVersion += 1;
-        this._onDidChangeTreeData.fire(undefined);
-    }
-
-    isNativeFindActive(): boolean {
-        return this.nativeFindActive;
     }
 
     getTreeItem(element: LayerTreeItem): vscode.TreeItem {
@@ -981,20 +963,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return !(element instanceof LayerItem && typeof element.layerIndex === 'number');
     }
 
-    private prepareNativeFindCandidate<T extends LayerTreeItem>(element: T): T {
-        element.description = undefined;
-        element.tooltip = undefined;
-        element.accessibilityInformation = {
-            label: String(element.label ?? ''),
-            role: element.accessibilityInformation?.role,
-        };
-        return element;
-    }
-
-    private getFlatTreeSearchMatches(
-        element?: LayerTreeItem,
-        options: { nativeFind?: boolean } = {},
-    ): LayerTreeItem[] {
+    private getFlatTreeSearchMatches(element?: LayerTreeItem): LayerTreeItem[] {
         const matches: LayerTreeItem[] = [];
         for (const child of this.getChildrenCore(element)) {
             if (child instanceof ArtifactTypeLayerItem) {
@@ -1008,11 +977,11 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 if (typeof child.id === 'string' && child.id.length > 0) {
                     child.id = `${child.id}|search:${this.searchVersion}`;
                 }
-                matches.push(options.nativeFind ? this.prepareNativeFindCandidate(child) : child);
+                matches.push(child);
             }
 
             if (canDescend) {
-                matches.push(...this.getFlatTreeSearchMatches(child, options));
+                matches.push(...this.getFlatTreeSearchMatches(child));
             }
         }
 
@@ -1020,15 +989,6 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        if (this.nativeFindActive && this.modeResolver() === 'tree') {
-            return element
-                ? []
-                : this.trackChildren(
-                      this.getFlatTreeSearchMatches(undefined, { nativeFind: true }),
-                      undefined,
-                  );
-        }
-
         if (this.searchQuery && this.modeResolver() === 'tree') {
             return element ? [] : this.trackChildren(this.getFlatTreeSearchMatches(), undefined);
         }
@@ -2255,9 +2215,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
     }
 
     getChildren(element?: LayerTreeItem): LayerTreeItem[] {
-        return this.searchQuery || this.nativeFindActive
-            ? this.getSearchFilteredChildren(element)
-            : this.getChildrenCore(element);
+        return this.searchQuery ? this.getSearchFilteredChildren(element) : this.getChildrenCore(element);
     }
 
     getExpandAllStrategy(): ExpandAllStrategy {

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -2024,33 +2024,25 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
                 element.repoId,
                 mode,
             );
-            if (mode === 'tree' && repoEntries.some((entry) => entry.normalizedPath === '')) {
-                if (element.repoId === BUILT_IN_CAPABILITY_REPO_ID) {
-                    return this.trackChildren(repoChildren, element);
-                }
-
-                const rootLayer = repoChildren.find((child) => child.pathKey === '(root)');
-                if (rootLayer) {
-                    return this.trackChildren([rootLayer], element);
-                }
-            }
-
             return this.trackChildren(repoChildren, element);
         }
 
         if (element instanceof LayerItem) {
-            const parentPath = element.pathKey === '(root)' ? '' : element.pathKey || '';
+            const isRootLayerNode = element.pathKey === '(root)';
+            const parentPath = isRootLayerNode ? '' : element.pathKey || '';
             const repoEntries = element.repoId
                 ? entries.filter((entry) => entry.repoId === element.repoId)
                 : entries.filter((entry) => entry.repoId === undefined);
 
             // Branch nodes stay structural; leaf capability nodes expose artifact-type browse rows.
-            const folderChildren = this.getTreeChildrenForPrefix(
-                repoEntries,
-                parentPath,
-                element.repoId,
-                mode,
-            ).filter((child) => child.pathKey !== '(root)');
+            const folderChildren = isRootLayerNode
+                ? []
+                : this.getTreeChildrenForPrefix(
+                      repoEntries,
+                      parentPath,
+                      element.repoId,
+                      mode,
+                  ).filter((child) => child.pathKey !== '(root)');
 
             if (typeof element.layerIndex === 'number' && mode === 'tree') {
                 const builtInRootLayer =

--- a/src/src/views/layersTreeView.ts
+++ b/src/src/views/layersTreeView.ts
@@ -951,7 +951,28 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
         return element;
     }
 
+    private canSearchDescendInto(element: LayerTreeItem): boolean {
+        if (element.collapsibleState === vscode.TreeItemCollapsibleState.None) {
+            return false;
+        }
+
+        if (this.modeResolver() !== 'tree') {
+            return true;
+        }
+
+        return !(element instanceof LayerItem && typeof element.layerIndex === 'number');
+    }
+
     private getSearchFilteredChildren(element?: LayerTreeItem): LayerTreeItem[] {
+        if (
+            this.searchQuery &&
+            this.modeResolver() === 'tree' &&
+            element instanceof LayerItem &&
+            typeof element.layerIndex === 'number'
+        ) {
+            return [];
+        }
+
         const children = this.getChildrenCore(element);
         if (!this.searchQuery) {
             return children;
@@ -959,9 +980,7 @@ export class LayersTreeViewProvider implements vscode.TreeDataProvider<LayerTree
 
         return children.filter((child) => {
             const descendantMatches =
-                child.collapsibleState === vscode.TreeItemCollapsibleState.None
-                    ? []
-                    : this.getSearchFilteredChildren(child);
+                this.canSearchDescendInto(child) ? this.getSearchFilteredChildren(child) : [];
             const include = this.matchesSearch(child) || descendantMatches.length > 0;
 
             if (include && descendantMatches.length > 0) {


### PR DESCRIPTION
## Summary
Merge the current `develop` branch into `main` to bring over the latest capability search and plugin-maintenance fixes.

## Includes
- flat capability search fixes and tree behavior corrections
- capability/plugin maintenance scope restrictions
- extension and engine test updates that cover the merged behavior

## Expected state
- `main` will match the current `develop` branch content for these fixes
- package versions remain at `0.3.0`
- this PR does not include a release changeset or `0.3.1` version bump, so the documented version-packages release flow is not yet armed
